### PR TITLE
Add arguments to export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.pyc
 .DS_Store
 brightway/import_agb/agribalyse3_no_param.CSV
-
+brightway/export_agb/processes-no-impacts.json

--- a/brightway/README.md
+++ b/brightway/README.md
@@ -58,6 +58,13 @@ Puis lancer le script d'export qui peut prendre plusieurs heures (!) :
 
     $ python export.py
 
+Il est possible d'utiliser l'option `--max` pour limiter le nombre de produits
+ciquals à exporter, et l'option `--no-impacts` pour ne pas calculer les impacts
+des procédés (ce qui exportera un fichier `processes-no-impacts.json` au lieu de
+`processes.json`) :
+
+    $ python export.py --max 1 --no-impacts # Beaucoup plus rapide, mais incomplet ;)
+
 Optionnellement, lancer le script de vérification des différences d'impacts :
 
     $ python checks.py

--- a/brightway/export_agb/checks.py
+++ b/brightway/export_agb/checks.py
@@ -70,8 +70,9 @@ def get_diff(impact_a, impact_b):
 def processes_for_step(step):
     """Liste de tous les process d'une étape."""
     processes = []
-    for category_processes in step.values():
-        processes += category_processes
+    for (category_name, category) in step.items():
+        if category_name != "mainProcess":
+            processes += category
     return processes
 
 

--- a/brightway/export_agb/export.py
+++ b/brightway/export_agb/export.py
@@ -7,7 +7,6 @@ import json
 
 import argparse
 import brightway2 as bw
-from brightway2 import *
 from collections import defaultdict
 from impacts import impacts
 import pandas as pd
@@ -17,7 +16,7 @@ import re
 def open_db(dbname):
     bw.projects.set_current("EF calculation")
     bw.bw2setup()
-    return Database(dbname)
+    return bw.Database(dbname)
 
 
 def get_ciqual_codes(filename):
@@ -198,7 +197,7 @@ def init_lcas(demand):
     lcas = {}
     for (key, method) in impacts.items():
         print("initializing method", method)
-        lca = LCA(demand, method)
+        lca = bw.LCA(demand, method)
         lca.lci()
         lca.lcia()
         lcas[key] = lca

--- a/brightway/export_agb/export.py
+++ b/brightway/export_agb/export.py
@@ -263,10 +263,15 @@ if __name__ == "__main__":
     print("Building product tree")
     (products, processes) = build_product_tree(ciqual_products)
 
+    print(f"Export de {len(products)} produits vers products.json")
+    export_json(products, "products.json")
+
+    processes_export_file = "processes.json"
     if args.no_impacts:
         # We don't compute impacts, but we still need to fix the processes dict so it has
         # string keys, and not "brightway activities"
         processes = {process["name"]: value for (process, value) in processes.items()}
+        processes_export_file = "processes-no-impacts.json"
     else:
         # Just get a random process, for example the very first one
         random_process = next(iter(processes))
@@ -274,8 +279,6 @@ if __name__ == "__main__":
 
         processes = compute_lca(processes, lcas)
 
-    print(f"Export de {len(products)} produits vers products.json")
-    export_json(products, "products.json")
-    print(f"Export de {len(processes)} produits vers processes.json")
-    export_json(processes, "processes.json")
+    print(f"Export de {len(processes)} produits vers {processes_export_file}")
+    export_json(processes, processes_export_file)
     print("Terminé.")


### PR DESCRIPTION
You can now use `--max` to only import a few ciqual products, and `--no-impacts` to not compute impacts for the processes (will save an incomplete `processes-no-impacts.json` file without the impacts).

As a side note, we realized that we have 4 codes that are duplicated in the agribalyse database, with different names (and so, different products) that have the same ciqual code : 

```
'Strawberry, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 13014]' (kilogram, None, None)
'Strawberry, in-season, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 13014]' (kilogram, None, None)
'Strawberry, off-season, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 13014]' (kilogram, None, None)
```
```
'French bean, raw, processed in FR | Ambient (average) | No packaging | Chilled at consumer | at consumer/FR [Ciqual code: 20061]' (kilogram, None, None)
'French bean, raw (Kenya by plane), processed in FR | Ambient (average) | No packaging | Chilled at consumer | at consumer/FR [Ciqual code: 20061]' (kilogram, None, None)
```
```
'Mango, pulp, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 13025]' (kilogram, None, None)
'Mango, pulp, raw (Brazil by plane), processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 13025]' (kilogram, None, None)
```
```
'Tomato, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 20047]' (kilogram, None, None)
'Tomato, in season, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 20047]' (kilogram, None, None)
'Tomato, off-season, raw, processed in FR | Ambient (average) | No packaging | No preparation | at consumer/FR [Ciqual code: 20047]' (kilogram, None, None)
```