### PR TITLE
chore: replace AGB3.2 beta with final

### DIFF
--- a/import_food.py
+++ b/import_food.py
@@ -20,7 +20,7 @@ CURRENT_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
 
 PROJECT = "ecobalyse"
 AGRIBALYSE31 = "AGB3.1.1.20230306.CSV.zip"  # Agribalyse 3.1
-AGRIBALYSE32 = "AGB32beta_08082024.CSV.zip"  # Agribalyse 3.2
+AGRIBALYSE32 = "AGB32_final.CSV.zip"  # Agribalyse 3.2
 GINKO = "CSV_369p_et_298chapeaux_final.csv.zip"  # additional organic processes
 PASTOECO = "pastoeco.CSV.zip"
 CTCPA = "Export emballages_PACK AGB_CTCPA.CSV.zip"
@@ -270,7 +270,7 @@ if __name__ == "__main__":
         print(f"{db} already imported")
 
     # AGRIBALYSE 3.2
-    if (db := "Agribalyse 3.2 beta 08/08/2024") not in bw2data.databases:
+    if (db := "Agribalyse 3.2") not in bw2data.databases:
         import_simapro_csv(
             join(DB_FILES_DIR, AGRIBALYSE32),
             db,


### PR DESCRIPTION
## :wrench: Problem

Even if the final version is now available, we are still using a beta version of AGB 3.2.

## :cake: Solution

Use the final version.

## :rotating_light:  Points to watch/comments

Packaging made by Martin on the beta versions were removed because they use hard-coded ids that don’t exist anymore in the final version.
Martin was consulted about this change.

## :desert_island: How to test

`npm run import:all` && `npm run export:all` should produce no diff.

Don’t forget that you could (and certainly should) setup your `BRIGHTWAY2_DIR` to a new directory when testing new imports like this one in order to not screw up your actual working BW installation. 
