### PR TITLE
fix: Retrieve impacts of WFLDB from SimaPro

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -45,6 +45,8 @@ def spproject(activity):
             return "Woolmark"
         case "PastoEco":
             return "AGB3.1.1 2023-03-06"
+        case "WFLDB":
+            return "WFLDB"
         case _:
             return "AGB3.1.1 2023-03-06"
 

--- a/common/export.py
+++ b/common/export.py
@@ -491,7 +491,13 @@ def find_id(dbname, activity):
 
 
 def compute_simapro_impacts(activity, method, impacts_py):
-    strprocess = urllib.parse.quote(activity["name"], encoding=None, errors=None)
+    name = (
+        activity["name"]
+        if spproject(activity) != "WFLDB"
+        # TODO this should probably done through disabling a strategy
+        else f"{activity['name']}/{activity['location']} U"
+    )
+    strprocess = urllib.parse.quote(name, encoding=None, errors=None)
     project = urllib.parse.quote(spproject(activity), encoding=None, errors=None)
     method = urllib.parse.quote(main_method, encoding=None, errors=None)
     api_request = f"http://simapro.ecobalyse.fr:8000/impact?process={strprocess}&project={project}&method={method}"

--- a/spapi/simapro.py
+++ b/spapi/simapro.py
@@ -41,9 +41,9 @@ async def impact(_: Request, project: str, process: str, method: str):
             server.OpenProject(project, "")
 
         print("Computing results...")
-        tmpproject = (
-            "World Food LCA Database" if project == "WFLDB" else project
-        )  # hack
+        # hack because the open project is "WFLDB"
+        # but the process are in the library project "World Food LCA Database"
+        tmpproject = "World Food LCA Database" if project == "WFLDB" else project
         existing = [
             e
             for e in [


### PR DESCRIPTION
## :wrench: Problem

Processes coming from WFLDB are not correctly retrieved from SimaPro, preventing from comparing them with brightway.

## :cake: Solution

added a hack for selecting the right simapro project, 

## :desert_island: How to test

Make an export and check that there are correct comparison graphs for WFLDB ingredients (such as turkish cherry)