### PR TITLE
chore: add tests for scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   ECOBALYSE_OUTPUT_DIR: ./public/data
+  FORCE_ENV_FOR_DYNACONF: testing
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  ECOBALYSE_OUTPUT_DIR: ./public/data
+
 jobs:
   ci:
     name: Lint and test

--- a/bin/export_icv.py
+++ b/bin/export_icv.py
@@ -108,6 +108,10 @@ def main(
             help=f"Brightway project name. Default to {settings.bw.project}.",
         ),
     ] = None,
+    multiprocessing: Annotated[
+        bool,
+        typer.Option(help="Use multiprocessing for faster computation."),
+    ] = True,
 ):
     """
     Compute the detailed impacts for all the databases in the default Brightway project.
@@ -155,9 +159,16 @@ def main(
                         )
                         nb_activity += 1
 
-            processes_with_impacts = pool.starmap(
-                get_process_with_impacts, activities_parameters
-            )
+            processes_with_impacts = []
+            if multiprocessing:
+                processes_with_impacts = pool.starmap(
+                    get_process_with_impacts, activities_parameters
+                )
+            else:
+                for activity_parameters in activities_parameters:
+                    processes_with_impacts.append(
+                        get_process_with_impacts(*activity_parameters)
+                    )
 
             logger.info(
                 f"-> Computed impacts for {len(processes_with_impacts)} processes in '{database_name}'"

--- a/bin/export_icv.py
+++ b/bin/export_icv.py
@@ -102,6 +102,12 @@ def main(
             help=f"Brightway project name. Default to {settings.bw.project}.",
         ),
     ] = settings.bw.project,
+    activity_name: Annotated[
+        Optional[str],
+        typer.Option(
+            help=f"Brightway project name. Default to {settings.bw.project}.",
+        ),
+    ] = None,
 ):
     """
     Compute the detailed impacts for all the databases in the default Brightway project.
@@ -133,11 +139,21 @@ def main(
             )
             for activity in db:
                 if "process" in activity.get("type") and (max < 0 or nb_activity < max):
-                    activities_paramaters.append(
-                        # Parameters of the `get_process_with_impacts` function
-                        (activity, main_method, impacts_py, IMPACTS_JSON, database_name)
-                    )
-                    nb_activity += 1
+                    if activity_name is None or (
+                        activity_name is not None
+                        and activity_name == activity.get("name")
+                    ):
+                        activities_paramaters.append(
+                            # Parameters of the `get_process_with_impacts` function
+                            (
+                                activity,
+                                main_method,
+                                impacts_py,
+                                IMPACTS_JSON,
+                                database_name,
+                            )
+                        )
+                        nb_activity += 1
 
             processes_with_impacts = pool.starmap(
                 get_process_with_impacts, activities_paramaters

--- a/bin/export_icv.py
+++ b/bin/export_icv.py
@@ -131,7 +131,7 @@ def main(
         db = bw2data.Database(database_name)
 
         with Pool(cpu_count) as pool:
-            activities_paramaters = []
+            activities_parameters = []
             nb_activity = 0
 
             logger.info(
@@ -143,7 +143,7 @@ def main(
                         activity_name is not None
                         and activity_name == activity.get("name")
                     ):
-                        activities_paramaters.append(
+                        activities_parameters.append(
                             # Parameters of the `get_process_with_impacts` function
                             (
                                 activity,
@@ -156,7 +156,7 @@ def main(
                         nb_activity += 1
 
             processes_with_impacts = pool.starmap(
-                get_process_with_impacts, activities_paramaters
+                get_process_with_impacts, activities_parameters
             )
 
             logger.info(

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -184,6 +184,17 @@ def with_corrected_impacts(impact_defs, frozen_processes, impacts="impacts"):
     return frozendict(processes_updated)
 
 
+def calculate_aggregate(aggregate_name, process_impacts, normalization_factors):
+    # We multiply by 10**6 to get the result in µPts
+    return sum(
+        10**6
+        * process_impacts[trigram]
+        / normalization_factors[f"{aggregate_name}_normalizations"][trigram]
+        * normalization_factors[f"{aggregate_name}_weightings"][trigram]
+        for trigram in normalization_factors[f"{aggregate_name}_normalizations"]
+    )
+
+
 def bytrigram(definitions, bynames):
     """takes the impact definitions and some impacts by name, return the impacts by trigram"""
     trigramsByName = {method[1]: trigram for trigram, method in definitions.items()}
@@ -204,20 +215,8 @@ def with_aggregated_impacts(impacts_json, frozen_processes, impacts="impacts"):
         updated_process = dict(process)
         updated_impacts = updated_process[impacts].copy()
 
-        updated_impacts["pef"] = sum(
-            10**6
-            * updated_impacts[trigram]
-            / factors["pef_normalizations"][trigram]
-            * factors["pef_weightings"][trigram]
-            for trigram in factors["pef_normalizations"]
-        )
-        updated_impacts["ecs"] = sum(
-            10**6
-            * updated_impacts[trigram]
-            / factors["ecs_normalizations"][trigram]
-            * factors["ecs_weightings"][trigram]
-            for trigram in factors["ecs_normalizations"]
-        )
+        updated_impacts["pef"] = calculate_aggregate("pef", updated_impacts, factors)
+        updated_impacts["ecs"] = calculate_aggregate("ecs", updated_impacts, factors)
 
         updated_process[impacts] = updated_impacts
         processes_updated[key] = updated_process

--- a/common/export.py
+++ b/common/export.py
@@ -389,6 +389,22 @@ def format_json(json_path):
     return subprocess.run(f"npm run fix:prettier {json_path}".split(" "))
 
 
+def display_changes_from_json(
+    processes_impacts_path,
+    processes_corrected_impacts,
+    dir,
+):
+    processes_impacts = os.path.join(dir, processes_impacts_path)
+
+    if os.path.isfile(processes_impacts):
+        logger.info(f"-> Displaying changes from {processes_impacts}...")
+        # Load old processes for comparison
+        oldprocesses = load_json(processes_impacts)
+
+        # Display changes
+        display_changes("id", oldprocesses, processes_corrected_impacts)
+
+
 def export_processes_to_dirs(
     processes_aggregated_path,
     processes_impacts_path,
@@ -405,13 +421,6 @@ def export_processes_to_dirs(
         logger.info(f"-> Exporting to {dir}...")
         processes_impacts = os.path.join(dir, processes_impacts_path)
         processes_aggregated = os.path.join(dir, processes_aggregated_path)
-
-        if os.path.isfile(processes_impacts):
-            # Load old processes for comparison
-            oldprocesses = load_json(processes_impacts)
-
-            # Display changes
-            display_changes("id", oldprocesses, processes_corrected_impacts)
 
         if extra_data is not None and extra_path is not None:
             extra_file = os.path.join(dir, extra_path)

--- a/ecobalyse_data/tests.py
+++ b/ecobalyse_data/tests.py
@@ -1,0 +1,8 @@
+import shutil
+
+from bw2data.project import projects
+
+
+def restore_archived_project(archive_path):
+    base_data_dir, _ = projects._get_base_directories()
+    shutil.unpack_archive(archive_path, base_data_dir)

--- a/food/export.py
+++ b/food/export.py
@@ -20,6 +20,7 @@ from common.export import (
     cached_search,
     check_ids,
     compute_impacts,
+    display_changes_from_json,
     export_json,
     export_processes_to_dirs,
     find_id,
@@ -212,6 +213,14 @@ if __name__ == "__main__":
     )
 
     export_json(activities_land_occ, ACTIVITIES_FILE, sort=True)
+
+    display_changes_from_json(
+        processes_impacts_path=os.path.join(
+            settings.food.dirname, settings.processes_impacts_file
+        ),
+        processes_corrected_impacts=processes_impacts,
+        dir=settings.output_dir,
+    )
 
     exported_files = export_processes_to_dirs(
         os.path.join(settings.food.dirname, settings.processes_aggregated_file),

--- a/object/export.py
+++ b/object/export.py
@@ -19,6 +19,7 @@ from common import (
 from common.export import (
     IMPACTS_JSON,
     compute_impacts,
+    display_changes_from_json,
     export_processes_to_dirs,
     format_json,
     generate_compare_graphs,
@@ -80,6 +81,14 @@ if __name__ == "__main__":
     )
     processes_aggregated_impacts = with_aggregated_impacts(
         IMPACTS_JSON, processes_impacts
+    )
+
+    display_changes_from_json(
+        processes_impacts_path=os.path.join(
+            settings.object.dirname, settings.processes_impacts_file
+        ),
+        processes_corrected_impacts=processes_impacts,
+        dir=settings.output_dir,
     )
 
     exported_files = export_processes_to_dirs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "dynaconf>=3.2.6",
     "orjson>=3.10.15",
     "typer>=0.15.1",
+    "pytest-mock>=3.14.0",
+    "ptpython>=3.0.29",
 ]
 
 [dependency-groups]

--- a/settings.toml
+++ b/settings.toml
@@ -36,3 +36,8 @@ DIRNAME="object"
 [default.textile]
 DIRNAME="textile"
 MATERIALS_FILE="materials.json"
+
+
+[testing.bw]
+BIOSPHERE="ecoinvent-3.9.1-biosphere"
+PROJECT="forwast"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import tempfile
+
+import pytest
+
+from common import brightway_patch as brightway_patch
+
+
+@pytest.fixture
+def temp_bw_dir():
+    dirpath = tempfile.mkdtemp()
+    os.environ["BRIGHTWAY2_DIR"] = dirpath

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,55 @@
 import os
 import tempfile
+from os.path import dirname
+from pathlib import Path
 
+import bw2data
+import orjson
 import pytest
+from bw2data import config as bwconfig
+from bw2data import projects
 
 from common import brightway_patch as brightway_patch
+from config import settings
+from ecobalyse_data.tests import restore_archived_project
+
+PROJECT_ROOT_DIR = dirname(dirname(__file__))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_test_settings():
+    settings.configure(FORCE_ENV_FOR_DYNACONF="testing")
+
+
+@pytest.fixture
+def forwast(temp_bw_dir, set_test_settings):
+    restore_archived_project(
+        os.path.join(
+            PROJECT_ROOT_DIR,
+            "tests/fixtures/bw-project-forwast-with-patched-ef31.tar.gz",
+        )
+    )
+
+    bw2data.projects.set_current(settings.bw.project)
 
 
 @pytest.fixture
 def temp_bw_dir():
-    dirpath = tempfile.mkdtemp()
-    os.environ["BRIGHTWAY2_DIR"] = dirpath
+    bwconfig.dont_warn = True
+    bwconfig.is_test = True
+    tempdir = Path(tempfile.mkdtemp())
+
+    os.environ["BRIGHTWAY2_DIR"] = str(tempdir)
+    projects.change_base_directories(
+        base_dir=tempdir,
+        base_logs_dir=tempdir,
+        project_name=settings.bw.project,
+        update=False,
+    )
+    projects._is_temp_dir = True
+
+
+@pytest.fixture
+def forwast_json_icv():
+    with open(os.path.join(PROJECT_ROOT_DIR, "tests/fixtures/forwast.json"), "rb") as f:
+        return orjson.loads(f.read())

--- a/tests/fixtures/forwast.json
+++ b/tests/fixtures/forwast.json
@@ -1,0 +1,35 @@
+{
+  "forwast": [
+    {
+      "categories": ["Input Output", "EU27 2003"],
+      "comment": "Location:  Unspecified\nTechnology:  Unspecified\nTime period:  Unspecified",
+      "impacts": {
+        "acd": 0.01570549584,
+        "cch": 2.107576844,
+        "ecs": 102.5847006401981,
+        "etf": 0.46898182729,
+        "etf_c": 0.49422404998,
+        "fru": 0.0,
+        "fwe": 0.0,
+        "htc": 0.0,
+        "htc_c": 0.0,
+        "htn": 5.963651765e-10,
+        "htn_c": 1.1052066718e-9,
+        "ior": 0.0,
+        "ldu": 0.0,
+        "mru": 0.0,
+        "ozd": 0.0,
+        "pco": 0.006508274766,
+        "pef": 112.97042336221818,
+        "pma": 9.50346722e-8,
+        "swe": 0.001544927202,
+        "tre": 0.0580423763,
+        "wtu": 0.0
+      },
+      "name": "_22 Vegetable and animal oils and fats, EU27",
+      "source": "forwast",
+      "sourceId": null,
+      "unit": "kg"
+    }
+  ]
+}

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -32,6 +32,9 @@ def test_export_icv_forwast(forwast, forwast_json_icv):
             output_file=fp,
             activity_name="_22 Vegetable and animal oils and fats, EU27",
             db=["forwast"],
+            # Doesn't work as expected in MAC OS X
+            # See https://github.com/MTES-MCT/ecobalyse-data/pull/55#pullrequestreview-2656329669
+            multiprocessing=False,
         )
         fp.close()
 

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -1,8 +1,10 @@
 import tempfile
 
+import bw2data
 import orjson
 
 from bin import export_bw_db, export_icv
+from config import settings
 from ecobalyse_data.bw import simapro_export
 
 
@@ -21,6 +23,24 @@ def test_export_icv(mocker):
             assert json_data == {}
 
 
+# Basic test to see if the script compiles
+def test_export_icv_forwast(forwast, forwast_json_icv):
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        # Just check that the main function runs as expected
+        export_icv.main(
+            project=settings.bw.project,
+            output_file=fp,
+            activity_name="_22 Vegetable and animal oils and fats, EU27",
+            db=["forwast"],
+        )
+        fp.close()
+
+        # And that it computes the expected data
+        with open(fp.name, "rb") as f:
+            json_data = orjson.loads(f.read())
+            assert json_data == forwast_json_icv
+
+
 def test_export_bw_db(mocker):
     # Just check that the imports are ok
 
@@ -28,3 +48,7 @@ def test_export_bw_db(mocker):
     with tempfile.NamedTemporaryFile(delete=False) as fp:
         export_bw_db.main(fp, "")
         simapro_export.export_db_to_simapro.assert_called_once()
+
+
+def test_forwast_restore(forwast):
+    assert list(bw2data.databases) == ["ecoinvent-3.9.1-biosphere", "forwast"]

--- a/tests/test_bin_scripts.py
+++ b/tests/test_bin_scripts.py
@@ -1,0 +1,30 @@
+import tempfile
+
+import orjson
+
+from bin import export_bw_db, export_icv
+from ecobalyse_data.bw import simapro_export
+
+
+# Basic test to see if the script compiles
+def test_export_icv(mocker):
+    mocker.patch("bw2data.databases", return_value=[])
+
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        # Just check that the main function runs as expected
+        export_icv.main(output_file=fp, cpu_count=1, max=1)
+        fp.close()
+
+        # And that it creates an empty file
+        with open(fp.name, "rb") as f:
+            json_data = orjson.loads(f.read())
+            assert json_data == {}
+
+
+def test_export_bw_db(mocker):
+    # Just check that the imports are ok
+
+    mocker.patch("ecobalyse_data.bw.simapro_export.export_db_to_simapro")
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        export_bw_db.main(fp, "")
+        simapro_export.export_db_to_simapro.assert_called_once()

--- a/textile/export.py
+++ b/textile/export.py
@@ -19,6 +19,7 @@ from common.export import (
     cached_search,
     check_ids,
     compute_impacts,
+    display_changes_from_json,
     export_processes_to_dirs,
     find_id,
     format_json,
@@ -144,6 +145,14 @@ if __name__ == "__main__":
 
     processes_aggregated_impacts = with_aggregated_impacts(
         IMPACTS_JSON, processes_impacts
+    )
+
+    display_changes_from_json(
+        processes_impacts_path=os.path.join(
+            settings.textile.dirname, settings.processes_impacts_file
+        ),
+        processes_corrected_impacts=processes_impacts,
+        dir=settings.output_dir,
     )
 
     exported_files = export_processes_to_dirs(

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566 },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -665,8 +674,10 @@ dependencies = [
     { name = "loguru" },
     { name = "notebook" },
     { name = "orjson" },
+    { name = "ptpython" },
     { name = "pydantic-settings" },
     { name = "pypardiso", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
+    { name = "pytest-mock" },
     { name = "typer" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
@@ -697,8 +708,10 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "notebook", specifier = ">=7.3.0" },
     { name = "orjson", specifier = ">=3.10.15" },
+    { name = "ptpython", specifier = ">=3.0.29" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
     { name = "pypardiso", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'", specifier = ">=0.4.6" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "typer", specifier = ">=0.15.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvicorn", specifier = ">=0.34.0" },
@@ -2200,6 +2213,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ptpython"
+version = "3.0.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "jedi" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/61/352792c9f47de98a910526ff8a684466a6217e53ffa6627b3781960e4f0d/ptpython-3.0.29.tar.gz", hash = "sha256:b9d625183aef93a673fc32cbe1c1fcaf51412e7a4f19590521cdaccadf25186e", size = 72622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/39/c6fd4dd531e067b6a01624126cff0b3ddc6569e22f83e48d8418ffa9e3be/ptpython-3.0.29-py2.py3-none-any.whl", hash = "sha256:65d75c4871859e4305a020c9b9e204366dceb4d08e0e2bd7b7511bd5e917a402", size = 67057 },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2430,6 +2458,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
## :wrench: Problem

We currently have no tests for the scripts in the `bin/` directory and some recent commits broke the scripts without any test failing.
And more generally, we have no way to do functional tests of our pipeline because of the lack of open source data.

## :cake: Solution

Add tests for the scripts in `bin/` and add the [forwast database](https://lca-net.com/publications/show/forwast-documentation-data-consolidation-calibration-scenario-parameterisation/) to the test fixtures. This database is the one advertised by the BW team ( https://learn.brightway.dev/en/latest/content/chapters/BW25/BW25_introduction.html#option-b ) to test BW without using a proprietary database.


## :rotating_light:  Points to watch/comments

It adds a 40MB file to the repo containing the forwast BW project released by the BW team at https://files.brightway.dev/forwast.tar.gz patched with the addition of our patched method `Environmental Footprint 3.1 (adapted) patch wtu`.

It will allow us to test the full pipeline at some point, but it’s not the subject of this PR.

## :desert_island: How to test

```bash
export FORCE_ENV_FOR_DYNACONF="testing"
uv run pytest
```

Should be green.