### PR TITLE
fix: change simapro project for AGB 3.1.1

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -55,7 +55,7 @@ def spproject(activity):
         case "Woolmark":
             return "Woolmark"
         case "PastoEco":
-            return "AGB3.1.1 2023-03-06"
+            return "Agribalyse 3.1.1"
         case "WFLDB":
             return "WFLDB"
         case _:


### PR DESCRIPTION
## :wrench: Problem

During the work on moving to AGB 3.2, we're forced to remove the AGRIBALU identifiers from SimaPro in the 3.1 version, which implies creating new identifiers.  The current AGB 3.1.1 project has been copied to `Agribalyse 3.1.1` project, which creates new MTE identifiers.

## :cake: Solution

- Change the mapping from the brightway database to the simapro project
- remove these identifiers from the ecobalyse explorer : https://github.com/MTES-MCT/ecobalyse/pull/947

## :desert_island: How to test

Check that we still can retrieve the impacts from simapro by running the export on food.