### PR TITLE
fix: set long-term factors to zero

### DIFF
--- a/common/export.py
+++ b/common/export.py
@@ -1,11 +1,11 @@
 import functools
 import json
 import math
-import os
 import subprocess
 import sys
 import urllib.parse
-from os.path import dirname
+from os import makedirs
+from os.path import dirname, join
 
 import bw2calc
 import bw2data
@@ -40,7 +40,7 @@ logger.add(sys.stderr, format="{time} {level} {message}", level="INFO")
 
 PROJECT_ROOT_DIR = dirname(dirname(__file__))
 
-with open(os.path.join(PROJECT_ROOT_DIR, settings.impacts_file)) as f:
+with open(join(PROJECT_ROOT_DIR, settings.impacts_file)) as f:
     IMPACTS_JSON = deepfreeze(json.load(f))
 
 
@@ -432,7 +432,7 @@ def csv_export_impact_comparison(compared_impacts, folder):
 
     df = pd.DataFrame(rows)
     df.to_csv(
-        os.path.join(PROJECT_ROOT_DIR, folder, settings.compared_impacts_file),
+        join(PROJECT_ROOT_DIR, folder, settings.compared_impacts_file),
         index=False,
     )
 
@@ -456,21 +456,6 @@ def format_json(json_path):
     return subprocess.run(f"npm run fix:prettier {json_path}".split(" "))
 
 
-def display_changes_from_json(
-    processes_impacts_path,
-    processes_corrected_impacts,
-    dir,
-):
-    processes_impacts = os.path.join(dir, processes_impacts_path)
-
-    if os.path.isfile(processes_impacts):
-        # Load old processes for comparison
-        oldprocesses = load_json(processes_impacts)
-
-        # Display changes
-        display_changes("id", oldprocesses, processes_corrected_impacts, use_rich=True)
-
-
 def export_processes_to_dirs(
     processes_aggregated_path,
     processes_impacts_path,
@@ -485,11 +470,11 @@ def export_processes_to_dirs(
     for dir in dirs:
         logger.info("")
         logger.info(f"-> Exporting to {dir}...")
-        processes_impacts = os.path.join(dir, processes_impacts_path)
-        processes_aggregated = os.path.join(dir, processes_aggregated_path)
+        processes_impacts = join(dir, processes_impacts_path)
+        processes_aggregated = join(dir, processes_aggregated_path)
 
         if extra_data is not None and extra_path is not None:
-            extra_file = os.path.join(dir, extra_path)
+            extra_file = join(dir, extra_path)
             export_json(extra_data, extra_file, sort=True)
             exported_files.append(extra_file)
 
@@ -588,7 +573,7 @@ def generate_compare_graphs(processes, impacts_py, graph_folder, output_dirname,
             logger.info(f"This hardcopied process cannot be plot: {name}")
         elif plot:
             logger.info(f"Plotting {name}")
-            os.makedirs(graph_folder, exist_ok=True)
+            makedirs(graph_folder, exist_ok=True)
             plot_impacts(
                 process_name=name,
                 impacts_smp=values.get("simapro_impacts", {}),

--- a/food/export.py
+++ b/food/export.py
@@ -3,8 +3,7 @@
 """Ingredients and processes export for food"""
 
 import argparse
-import os
-from os.path import abspath, dirname
+from os.path import abspath, dirname, join
 
 import bw2calc
 import bw2data
@@ -20,7 +19,7 @@ from common.export import (
     cached_search,
     check_ids,
     compute_impacts,
-    display_changes_from_json,
+    display_changes,
     export_json,
     export_processes_to_dirs,
     find_id,
@@ -42,12 +41,12 @@ PROJECT_ROOT_DIR = dirname(dirname(abspath(__file__)))
 dirs_to_export_to = [settings.output_dir]
 
 if settings.local_export:
-    dirs_to_export_to.append(os.path.join(PROJECT_ROOT_DIR, "public", "data"))
+    dirs_to_export_to.append(join(PROJECT_ROOT_DIR, "public", "data"))
 
 # Configuration
 
-PROJECT_FOOD_DIR = os.path.join(PROJECT_ROOT_DIR, settings.food.dirname)
-ACTIVITIES_FILE = os.path.join(PROJECT_FOOD_DIR, settings.activities_file)
+PROJECT_FOOD_DIR = join(PROJECT_ROOT_DIR, settings.food.dirname)
+ACTIVITIES_FILE = join(PROJECT_FOOD_DIR, settings.activities_file)
 
 LAND_OCCUPATION_METHOD = ("selected LCI results", "resource", "land occupation")
 GRAPH_FOLDER = f"{PROJECT_ROOT_DIR}/food/impact_comparison"
@@ -180,7 +179,7 @@ if __name__ == "__main__":
 
     # ecosystemic factors
     ecosystemic_factors = load_ecosystemic_dic(
-        os.path.join(
+        join(
             PROJECT_FOOD_DIR,
             settings.food.ecosystemic_factors_file,
         )
@@ -189,8 +188,8 @@ if __name__ == "__main__":
         ingredients, ecosystemic_factors
     )
 
-    feed_file = load_json(os.path.join(PROJECT_FOOD_DIR, settings.food.feed_file))
-    ugb = load_ugb_dic(os.path.join(PROJECT_FOOD_DIR, settings.food.ugb_file))
+    feed_file = load_json(join(PROJECT_FOOD_DIR, settings.food.feed_file))
+    ugb = load_ugb_dic(join(PROJECT_FOOD_DIR, settings.food.ugb_file))
     ingredients_animal_es = compute_animal_ecosystemic_services(
         ingredients_veg_es, activities_land_occ, ecosystemic_factors, feed_file, ugb
     )
@@ -214,22 +213,23 @@ if __name__ == "__main__":
 
     export_json(activities_land_occ, ACTIVITIES_FILE, sort=True)
 
-    display_changes_from_json(
-        processes_impacts_path=os.path.join(
-            settings.food.dirname, settings.processes_impacts_file
-        ),
-        processes_corrected_impacts=processes_impacts,
-        dir=settings.output_dir,
+    old_processes = load_json(
+        join(
+            settings.output_dir,
+            settings.food.dirname,
+            settings.processes_impacts_file,
+        )
     )
+    display_changes("id", old_processes, processes_impacts, use_rich=True)
 
     exported_files = export_processes_to_dirs(
-        os.path.join(settings.food.dirname, settings.processes_aggregated_file),
-        os.path.join(settings.food.dirname, settings.processes_impacts_file),
+        join(settings.food.dirname, settings.processes_aggregated_file),
+        join(settings.food.dirname, settings.processes_impacts_file),
         processes_impacts,
         processes_aggregated_impacts,
         dirs_to_export_to,
         extra_data=ingredients_animal_es,
-        extra_path=os.path.join(settings.food.dirname, settings.food.ingredients_file),
+        extra_path=join(settings.food.dirname, settings.food.ingredients_file),
     )
     exported_files.append(ACTIVITIES_FILE)
 

--- a/import_method.py
+++ b/import_method.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import copy
 import functools
 import os
 from os.path import dirname, join
@@ -67,6 +68,7 @@ def import_method(datapath=METHODPATH, biosphere=settings.bw.biosphere):
         ),
         functools.partial(match_subcategories, biosphere_db_name=ef.biosphere_name),
     ]
+    ef.strategies.append(noLT)
     ef.apply_strategies()
     print(f"biosphere3 size: {len(bw2data.Database('biosphere3'))}")
     ef.statistics()
@@ -82,6 +84,19 @@ def import_method(datapath=METHODPATH, biosphere=settings.bw.biosphere):
 
     ef.write_methods(overwrite=True)
     print(f"### Finished importing {METHODNAME}\n")
+
+
+def noLT(db):
+    new_db = []
+    for method in db:
+        new_method = copy.deepcopy(method)
+        for k, v in new_method.items():
+            if k == "exchanges":
+                for cf in v:
+                    if any(["long-term" in cat for cat in cf["categories"]]):
+                        cf["amount"] = 0
+        new_db.append(new_method)
+    return new_db
 
 
 if __name__ == "__main__":

--- a/object/export.py
+++ b/object/export.py
@@ -4,9 +4,8 @@
 """Export des processes pour les objets"""
 
 import argparse
-import os
 import sys
-from os.path import abspath, dirname
+from os.path import abspath, dirname, join
 
 from bw2data.project import projects
 from frozendict import frozendict
@@ -19,7 +18,7 @@ from common import (
 from common.export import (
     IMPACTS_JSON,
     compute_impacts,
-    display_changes_from_json,
+    display_changes,
     export_processes_to_dirs,
     format_json,
     generate_compare_graphs,
@@ -29,12 +28,12 @@ from common.impacts import impacts as impacts_py
 from config import settings
 
 PROJECT_ROOT_DIR = dirname(dirname(abspath(__file__)))
-PROJECT_OBJECT_DIR = os.path.join(PROJECT_ROOT_DIR, settings.object.dirname)
+PROJECT_OBJECT_DIR = join(PROJECT_ROOT_DIR, settings.object.dirname)
 
 dirs_to_export_to = [settings.output_dir]
 
 if settings.local_export:
-    dirs_to_export_to.append(os.path.join(PROJECT_ROOT_DIR, "public", "data"))
+    dirs_to_export_to.append(join(PROJECT_ROOT_DIR, "public", "data"))
 
 # Configuration
 GRAPH_FOLDER = f"{PROJECT_ROOT_DIR}/object/impact_comparison"
@@ -61,7 +60,7 @@ if __name__ == "__main__":
     projects.set_current(settings.bw.project)
 
     # Load activities
-    activities = load_json(os.path.join(PROJECT_OBJECT_DIR, settings.activities_file))
+    activities = load_json(join(PROJECT_OBJECT_DIR, settings.activities_file))
 
     # Create process list
     processes = create_process_list(activities)
@@ -83,17 +82,23 @@ if __name__ == "__main__":
         IMPACTS_JSON, processes_impacts
     )
 
-    display_changes_from_json(
-        processes_impacts_path=os.path.join(
-            settings.object.dirname, settings.processes_impacts_file
-        ),
-        processes_corrected_impacts=processes_impacts,
-        dir=settings.output_dir,
+    old_processes = load_json(
+        join(
+            settings.output_dir,
+            settings.object.dirname,
+            settings.processes_impacts_file,
+        )
+    )
+    display_changes(
+        "id",
+        old_processes,
+        processes_impacts,
+        use_rich=True,
     )
 
     exported_files = export_processes_to_dirs(
-        os.path.join(settings.object.dirname, settings.processes_aggregated_file),
-        os.path.join(settings.object.dirname, settings.processes_impacts_file),
+        join(settings.object.dirname, settings.processes_aggregated_file),
+        join(settings.object.dirname, settings.processes_impacts_file),
         processes_impacts,
         processes_aggregated_impacts,
         dirs_to_export_to,

--- a/textile/export.py
+++ b/textile/export.py
@@ -3,8 +3,7 @@
 """Materials and processes export for textile"""
 
 import argparse
-import os
-from os.path import abspath, dirname
+from os.path import abspath, dirname, join
 
 import bw2data
 from frozendict import frozendict
@@ -19,7 +18,7 @@ from common.export import (
     cached_search,
     check_ids,
     compute_impacts,
-    display_changes_from_json,
+    display_changes,
     export_processes_to_dirs,
     find_id,
     format_json,
@@ -32,12 +31,12 @@ from config import settings
 BW_DATABASES = bw2data.databases
 
 PROJECT_ROOT_DIR = dirname(dirname(abspath(__file__)))
-PROJECT_TEXTILE_DIR = os.path.join(PROJECT_ROOT_DIR, settings.textile.dirname)
+PROJECT_TEXTILE_DIR = join(PROJECT_ROOT_DIR, settings.textile.dirname)
 
 dirs_to_export_to = [settings.output_dir]
 
 if settings.local_export:
-    dirs_to_export_to.append(os.path.join(PROJECT_ROOT_DIR, "public", "data"))
+    dirs_to_export_to.append(join(PROJECT_ROOT_DIR, "public", "data"))
 
 
 # Configuration
@@ -121,9 +120,7 @@ if __name__ == "__main__":
 
     bw2data.projects.set_current(settings.bw.project)
 
-    activities = tuple(
-        load_json(os.path.join(PROJECT_TEXTILE_DIR, settings.activities_file))
-    )
+    activities = tuple(load_json(join(PROJECT_TEXTILE_DIR, settings.activities_file)))
 
     materials = create_material_list(activities)
 
@@ -147,24 +144,23 @@ if __name__ == "__main__":
         IMPACTS_JSON, processes_impacts
     )
 
-    display_changes_from_json(
-        processes_impacts_path=os.path.join(
-            settings.textile.dirname, settings.processes_impacts_file
-        ),
-        processes_corrected_impacts=processes_impacts,
-        dir=settings.output_dir,
+    old_processes = load_json(
+        join(
+            settings.output_dir,
+            settings.textile.dirname,
+            settings.processes_impacts_file,
+        )
     )
+    display_changes("id", old_processes, processes_impacts, use_rich=True)
 
     exported_files = export_processes_to_dirs(
-        os.path.join(settings.textile.dirname, settings.processes_aggregated_file),
-        os.path.join(settings.textile.dirname, settings.processes_impacts_file),
+        join(settings.textile.dirname, settings.processes_aggregated_file),
+        join(settings.textile.dirname, settings.processes_impacts_file),
         processes_impacts,
         processes_aggregated_impacts,
         dirs_to_export_to,
         extra_data=materials,
-        extra_path=os.path.join(
-            settings.textile.dirname, settings.textile.materials_file
-        ),
+        extra_path=join(settings.textile.dirname, settings.textile.materials_file),
     )
 
     format_json(" ".join(exported_files))


### PR DESCRIPTION
## :wrench: Problem

[Climate change an biodiversity urgency ](https://www.notion.so/4f0841edbc29408eb147558e53fe2acd?v=40d0d544eb8e4c03891da1f9aad8b6cd&p=1b4b056852fc80f6b45bdbde6e8993e3&pm=s)

## :cake: Solution

Add a strategy to remove LT emissions from the EF3.1 adapted method we're using.

## :rotating_light:  Points to watch/comments

Mostly only constructed processes change. The noLT checkbox on SimaPro doesn't seem accessible through the COM intf. So we definitely need to move to brightway-only impacts first.

## :desert_island: How to test

delete the current method `npm run import:delete_methods` then reimport it `npm run import:method` then do an export `npm run export:all` and check the changes (mostly ior and fwe)