### PR TITLE
refactor: use alias instead of id for feed

### DIFF
--- a/food/ecosystemic_services/feed.json
+++ b/food/ecosystemic_services/feed.json
@@ -1,151 +1,151 @@
 {
-  "15e2dfa0-9b5f-4bc9-a3ed-885f56061bc0": {
-    "086b58da-1c4c-40a8-9327-37477d04cfba": 0.28,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 2.48,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 1.11,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.56
+  "beef-with-bone": {
+    "grazed-grass-permanent": 24.51,
+    "grazed-grass-temporary": 3.3,
+    "silage-maize-fr": 2.23,
+    "soft-wheat-fr": 0.83,
+    "soybean-br-deforestation": 0.35
   },
-  "22179caa-eb41-49c0-ae04-49eda23da4da": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.44,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 1.04,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 4.13,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 30.63,
-    "dc872330-8d35-4b02-bf45-4481b89a093e": 2.79
+  "beef-without-bone": {
+    "grazed-grass-permanent": 30.63,
+    "grazed-grass-temporary": 4.13,
+    "silage-maize-fr": 2.79,
+    "soft-wheat-fr": 1.04,
+    "soybean-br-deforestation": 0.44
   },
-  "2bf307e8-8cb0-400b-a4f1-cf615d9e96f4": {
-    "305cc005-eb5c-4e94-b5cf-9aa21c619577": 0.071,
-    "585c8bb1-1aaa-4c33-a5c1-84c886bb7ec3": 0.0384,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.0477,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 0.579,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 0.814
+  "beef-without-bone-organic": {
+    "alfalfa-organic": 1.11,
+    "grazed-grass-permanent": 28.34,
+    "grazed-grass-temporary": 8.45,
+    "oats-organic": 0.26,
+    "silage-maize-organic": 0.63,
+    "soft-wheat-organic": 0.36,
+    "triticale-organic": 1.3
   },
-  "3fd1b6d5-58d9-40eb-b215-d2e8c2876a5f": {
-    "c88d387e-8435-4741-b742-0094dbdcee45": 51.73
+  "chicken-breast": {
+    "barley": 0.87,
+    "soft-wheat-fr": 1.23,
+    "soybean-br-deforestation": 0.87,
+    "sweet-corn-fr": 1.9
   },
-  "41d65ed4-230f-4a47-a67c-9a8015f50420": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.53,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 1.27,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 5.05,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 37.5,
-    "dc872330-8d35-4b02-bf45-4481b89a093e": 3.42
+  "chicken-breast-br-max": {
+    "barley": 0.87,
+    "soft-wheat-fr": 1.23,
+    "soybean-feed": 0.87,
+    "sweet-corn-br": 1.9
   },
-  "4de5e41e-3271-4489-aa27-a973e4045082": {
-    "3c16dc23-021d-45ef-8805-c77b043b041a": 1.07,
-    "585c8bb1-1aaa-4c33-a5c1-84c886bb7ec3": 1.56,
-    "8cf0b0ce-7ae7-4123-8fee-823b4c190418": 1.46,
-    "92d34545-6952-466e-bf6d-c1f1f6069b48": 0.58,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.72
+  "chicken-breast-fr": {
+    "barley": 0.87,
+    "soft-wheat-fr": 1.23,
+    "soybean-feed": 0.87,
+    "sweet-corn-fr": 1.9
   },
-  "4e3009f3-1b33-41d7-b6f3-dc7230331da0": {
-    "1af0933a-0139-480c-832d-053513d0ccba": 0.32,
-    "305cc005-eb5c-4e94-b5cf-9aa21c619577": 0.77,
-    "585c8bb1-1aaa-4c33-a5c1-84c886bb7ec3": 1.59,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.44,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 10.35,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 34.68,
-    "fd187fa6-9cbc-4839-b13f-365c5371cee6": 1.36
+  "chicken-breast-fr-organic": {
+    "barley": 0.87,
+    "soft-wheat-organic": 0.63,
+    "soybean-organic": 0.87,
+    "sweet-corn-organic-fr": 2.91
   },
-  "755225f1-f0c5-497f-b8a9-263828a84a22": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.28,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 2.61,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 0.74,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.56
+  "chicken-breast-organic": {
+    "barley": 0.87,
+    "soft-wheat-organic": 0.63,
+    "soybean-organic": 0.87,
+    "sweet-corn-organic-fr": 2.91
   },
-  "7ef7399a-1d56-4947-b773-9f6438a50fda": {
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 0.485,
-    "92d34545-6952-466e-bf6d-c1f1f6069b48": 0.204,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 1.09,
-    "bfdf1505-8426-499e-8286-a1e4b4920c7e": 0.274
+  "cooked-ham": {
+    "barley": 0.56,
+    "soft-wheat-fr": 2.61,
+    "soybean-br-deforestation": 0.28,
+    "sweet-corn-fr": 0.74
   },
-  "8f3863e7-f981-4367-90a2-e1aaa096a6e0": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.0646,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 0.0857,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 0.438,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 0.175,
-    "dc872330-8d35-4b02-bf45-4481b89a093e": 0.349
+  "cooked-ham-fr": {
+    "barley": 0.56,
+    "soft-wheat-fr": 2.48,
+    "soybean-feed": 0.28,
+    "sweet-corn-fr": 1.11
   },
-  "8fb5024c-ceec-4201-b069-ea253c537ad6": {
-    "086b58da-1c4c-40a8-9327-37477d04cfba": 0.87,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 1.23,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.87,
-    "be9a2aa4-4c8b-4801-abcf-01ba1581f053": 1.9
+  "cooked-ham-organic": {
+    "barley-organic": 1.07,
+    "bean-organic": 1.46,
+    "soft-wheat-organic": 0.72,
+    "soybean-organic": 0.58,
+    "triticale-organic": 1.56
   },
-  "9cbc31e9-80a4-4b87-ac4b-ddc051c47f69": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.35,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 0.567,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 0.977
+  "egg-bleublanccoeur": {
+    "bean-fr": 0.274,
+    "soft-wheat-organic": 1.09,
+    "soybean-organic": 0.204,
+    "sweet-corn-fr": 0.485
   },
-  "9db6b0d1-941a-4dda-a347-b7a7fee8fd46": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.35,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 0.83,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 3.3,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 24.51,
-    "dc872330-8d35-4b02-bf45-4481b89a093e": 2.23
+  "egg-indoor-code2": {
+    "soft-wheat-fr": 0.682,
+    "soybean-br-deforestation": 0.471,
+    "sweet-corn-fr": 1.18
   },
-  "a360871c-fc35-4cb3-af2c-5eeb8bd6f984": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.87,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 1.23,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 1.9,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.87
+  "egg-indoor-code3": {
+    "soft-wheat-fr": 0.567,
+    "soybean-br-deforestation": 0.35,
+    "sweet-corn-fr": 0.977
   },
-  "b19b0dc0-3478-46a0-b8a1-3225ea939ff1": {
-    "741c0970-2823-430a-b4e4-e61ce08ea95a": 2.91,
-    "92d34545-6952-466e-bf6d-c1f1f6069b48": 0.87,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.63,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.87
+  "egg-organic-code0": {
+    "soft-wheat-organic": 0.445,
+    "soybean-organic": 0.342,
+    "sunflower-organic": 0.13,
+    "sweet-corn-organic-fr": 0.8
   },
-  "b2e75be9-65b8-487d-b5b3-f9c2aa047cf7": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.453,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 0.644,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 1.14
+  "egg-outdoor-code1": {
+    "soft-wheat-fr": 0.644,
+    "soybean-br-deforestation": 0.453,
+    "sweet-corn-fr": 1.14
   },
-  "b682ae30-9df9-4385-9005-4b4725c70d54": {
-    "741c0970-2823-430a-b4e4-e61ce08ea95a": 2.91,
-    "92d34545-6952-466e-bf6d-c1f1f6069b48": 0.87,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.63,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.87
+  "ground-beef": {
+    "grazed-grass-permanent": 37.5,
+    "grazed-grass-temporary": 5.05,
+    "silage-maize-fr": 3.42,
+    "soft-wheat-fr": 1.27,
+    "soybean-br-deforestation": 0.53
   },
-  "ce073919-1aff-4892-a1f5-b25ee94bccd8": {
-    "34a88056-cd23-40e6-8eaa-6a64595fa9b2": 6.33,
-    "4b3c39a6-496c-416c-a42a-8d4c2fc788da": 6.1,
-    "94c4be9e-452d-4870-b1a2-5d2404a0490b": 12.68
+  "ground-beef-feedlot": {
+    "barley-eu": 6.33,
+    "oats-glo": 12.68,
+    "oilseed-feed": 6.1
   },
-  "cf30d3bc-e99c-418a-b7e3-89a894d410a5": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.471,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 0.682,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 1.18
+  "ground-beef-grass-fed": {
+    "grazed-grass-permanent": 51.73
   },
-  "cfd4a437-aa49-49ff-818e-353421f2fc09": {
-    "741c0970-2823-430a-b4e4-e61ce08ea95a": 0.8,
-    "92d34545-6952-466e-bf6d-c1f1f6069b48": 0.342,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.445,
-    "dbcc6b38-8309-4bb0-a66e-525ec9dcc79c": 0.13
+  "ground-beef-organic": {
+    "alfalfa-organic": 1.36,
+    "grazed-grass-permanent": 34.68,
+    "grazed-grass-temporary": 10.35,
+    "oats-organic": 0.32,
+    "silage-maize-organic": 0.77,
+    "soft-wheat-organic": 0.44,
+    "triticale-organic": 1.59
   },
-  "d79e0fce-8633-4189-a937-7b8010abafed": {
-    "141f76d7-fe36-4f17-b7da-043ac884a309": 0.91,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 2.94,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 12,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 25
+  "lamb-meat-without-bone": {
+    "grazed-grass-permanent": 25,
+    "grazed-grass-temporary": 12,
+    "soft-wheat-fr": 2.94,
+    "soybean-br-deforestation": 0.91
   },
-  "e07f7703-c4f7-479e-a8ac-bb73d3f08c78": {
-    "3c16dc23-021d-45ef-8805-c77b043b041a": 1.5,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 2.94,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 14,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 67
+  "lamb-meat-without-bone-organic": {
+    "barley-organic": 1.5,
+    "grazed-grass-permanent": 67,
+    "grazed-grass-temporary": 14,
+    "soft-wheat-organic": 2.94
   },
-  "f94df72e-20fd-4cc5-ab64-ce3921649d58": {
-    "086b58da-1c4c-40a8-9327-37477d04cfba": 0.87,
-    "38788025-a65e-4edf-a92f-aab0b89b0d61": 1.23,
-    "40fa68b6-381e-4dd6-ba70-8b43cfdee64e": 1.9,
-    "ab087863-f311-4066-8e93-4d7f6e0db2b2": 0.87
+  "milk": {
+    "grazed-grass-permanent": 0.175,
+    "grazed-grass-temporary": 0.438,
+    "silage-maize-fr": 0.349,
+    "soft-wheat-fr": 0.0857,
+    "soybean-br-deforestation": 0.0646
   },
-  "ff532795-d725-4c6b-82bc-022d38b83bff": {
-    "1af0933a-0139-480c-832d-053513d0ccba": 0.26,
-    "305cc005-eb5c-4e94-b5cf-9aa21c619577": 0.63,
-    "585c8bb1-1aaa-4c33-a5c1-84c886bb7ec3": 1.3,
-    "a98b8776-a96d-48e9-b218-976f5452907a": 0.36,
-    "ba97e4b9-1fac-4f92-bed1-9889e3ae631d": 8.45,
-    "c88d387e-8435-4741-b742-0094dbdcee45": 28.34,
-    "fd187fa6-9cbc-4839-b13f-365c5371cee6": 1.11
+  "milk-organic": {
+    "grazed-grass-permanent": 0.814,
+    "grazed-grass-temporary": 0.579,
+    "silage-maize-organic": 0.071,
+    "soft-wheat-organic": 0.0477,
+    "triticale-organic": 0.0384
   }
 }


### PR DESCRIPTION
## :wrench: Problem

Currently feed.json is written with `id` but it make it very tough to work with

## :cake: Solution

Use `alias` for feed.json


## :rotating_light:  Points to watch/comments

Tests pass but there are warnings (that were present before) as some feed ingredients are not present in `tests/fixtures/food/activities.json`

```
/private/var/folders/3y/bnd5cl950kxf8v1864bfyl4c0000gn/T/pytest-of-paulboosz/pytest-64/test_export_ingredients0
[12:13:57] INFO     -> Loading activities file 'tests/fixtures/food/activities.json'                                                                                                                                                                  food.py:242
           ERROR    -> bean-fr not in activities list, can't compute ecs                                                                                                                                                                              food.py:202
           ERROR    -> grazed-grass-temporary not in activities list, can't compute ecs                                                                                                                                                               food.py:202
           ERROR    -> grazed-grass-temporary not in activities list, can't compute ecs                                                                                                                                                               food.py:202                                                                 export.py:176

```

## :desert_island: How to test

`npm run export:food` should create no diff