### PR TITLE
fix: Show negative changes (fixes #74)

### DIFF
--- a/common/export.py
+++ b/common/export.py
@@ -55,7 +55,7 @@ def get_changes(old_impacts, new_impacts, process_name, only_impacts=[]):
             else:
                 percent_change = 100 * (new_value - old_value) / old_value
 
-            if percent_change > 0.1:
+            if abs(percent_change) > 0.1:
                 changes.append(
                     {
                         "trg": trigram,


### PR DESCRIPTION
## :wrench: Problem

Negative impact changes don't appear in the change table

## :cake: Solution

Compare the absolute value of the change with the 0.1% threshold

## :desert_island: How to test

Check on a impact-lowering PR that changes are shown during export. Ex: #63 