### PR TITLE
refactor: gather ecs and pef at the top of the change table

### DIFF
--- a/common/export.py
+++ b/common/export.py
@@ -70,7 +70,7 @@ def get_changes(old_impacts, new_impacts, process_name, only_impacts=[]):
 
 
 def display_changes_table(changes, sort_by_key="%diff"):
-    changes.sort(key=lambda c: c[sort_by_key])
+    changes.sort(key=lambda c: (c["trg"] != "ecs", c["trg"] != "pef", c[sort_by_key]))
 
     table = Table(title="Review changes", show_header=True, show_footer=True)
 


### PR DESCRIPTION
## :wrench: Problem

When there are a lot of impact changes, while doing an export, it's difficult to get a synthetic view of the global ECS or PEF changes, as the `pef` and `ecs` trigram are mixed with others.

## :cake: Solution

Gather the ECS and PEF changes at the top of the table.

## :desert_island: How to test

Make an export on an impact-modifying PR and check the change table.
(See on https://github.com/MTES-MCT/ecobalyse-data/pull/63 )
