### PR TITLE
feat: add component creation endpoint

### DIFF
--- a/backend/src/app/domain/components/controllers/component.py
+++ b/backend/src/app/domain/components/controllers/component.py
@@ -8,9 +8,9 @@ from advanced_alchemy.service.typing import (
 )
 from app.domain.components import urls
 from app.domain.components.deps import provide_components_service
-from app.domain.components.schemas import Component, ComponentUpdate
+from app.domain.components.schemas import Component, ComponentCreate, ComponentUpdate
 from app.lib.deps import create_filter_dependencies
-from litestar import delete, get, patch
+from litestar import delete, get, patch, post
 from litestar.controller import Controller
 from litestar.di import Provide
 from litestar.params import Parameter
@@ -52,6 +52,18 @@ class ComponentController(Controller):
             type=list[Component],  # type: ignore[valid-type]
             from_attributes=True,
         )
+
+    @post(operation_id="CreateComponent", path=urls.COMPONENT_CREATE)
+    async def create_component(
+        self,
+        data: ComponentCreate,
+        components_service: ComponentService,
+    ) -> Component:
+        """Create a component."""
+
+        component = await components_service.create(data=data.to_dict())
+
+        return components_service.to_schema(component, schema_type=Component)
 
     @patch(operation_id="UpdateComponent", path=urls.COMPONENT_UPDATE)
     async def update_component(

--- a/backend/src/app/domain/components/schemas.py
+++ b/backend/src/app/domain/components/schemas.py
@@ -22,6 +22,7 @@ class Component(CamelizedBaseStruct):
 
 class ComponentCreate(CamelizedBaseStruct):
     name: str
+    elements: list[ComponentElement]
 
 
 class ComponentElement(CamelizedBaseStruct, omit_defaults=True):

--- a/backend/tests/integration/test_components.py
+++ b/backend/tests/integration/test_components.py
@@ -8,6 +8,22 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.anyio
 
 
+async def test_components_create(client: "AsyncClient") -> None:
+    response = await client.post(
+        "/api/components",
+        json={
+            "name": "New Component",
+            "elements": [
+                {"amount": 0.91125, "material": "59b42284-3e45-5343-8a20-1d7d66137461"}
+            ],
+        },
+    )
+    json = response.json()
+    assert response.status_code == 201
+    assert json["name"] == "New Component "
+    assert len(json["elements"]) == 1
+
+
 async def test_components_update(client: "AsyncClient") -> None:
     response = await client.patch(
         "/api/components/8ca2ca05-8aec-4121-acaa-7cdcc03150a9",

--- a/backend/tests/integration/test_components.py
+++ b/backend/tests/integration/test_components.py
@@ -22,6 +22,7 @@ async def test_components_create(client: "AsyncClient") -> None:
     assert response.status_code == 201
     assert json["name"] == "New Component "
     assert len(json["elements"]) == 1
+    assert len(json["id"]) == 32
 
 
 async def test_components_update(client: "AsyncClient") -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -709,7 +710,7 @@ dev = [
 requires-dist = [
     { name = "bw2analyzer", specifier = "==0.11.7" },
     { name = "bw2calc", specifier = "==2.0.1" },
-    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869#1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
+    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
     { name = "bw2io", extras = ["multifunctional"], specifier = "==0.9.5" },
     { name = "bw2parameters", specifier = "==1.1.0" },
     { name = "deadcode", specifier = ">=2.4.1" },


### PR DESCRIPTION
I have no idea what I'm doing, but:

```
$ cat ~/Desktop/comp.json
{
  "elements": [
    {
      "amount": 0.91125,
      "material": "59b42284-3e45-5343-8a20-1d7d66137461"
    }
  ],
  "name": "Test Comp"
}

$ http POST http://127.0.0.1:8000/api/components < ~/Desktop/comp.json
HTTP/1.1 201 Created
content-length: 146
content-type: application/json
date: Wed, 16 Apr 2025 16:18:09 GMT
server: granian

{
    "elements": [
        {
            "amount": 0.91125,
            "material": "59b42284-3e45-5343-8a20-1d7d66137461"
        }
    ],
    "id": "afba2042-7a08-450c-87ec-238767ccebc9",
    "name": "Test Comp"
}
```