### PR TITLE
feat: improve processes export performance using multiprocessing

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-
 import json
 import logging
+import multiprocessing
 import os
 from enum import Enum
 from pathlib import Path
@@ -126,6 +126,14 @@ def processes(
         bool,
         typer.Option(help="Use simapro"),
     ] = False,
+    # Take all the cores available minus one to avoid locking the system
+    # If only one core is available, use it (that’s what the `or 1` is for)
+    cpu_count: Annotated[
+        Optional[int],
+        typer.Option(
+            help="The number of CPUs/cores to use for computation. Default to MAX-1."
+        ),
+    ] = multiprocessing.cpu_count() - 1 or 1,
     plot: bool = typer.Option(False, "--plot", "-p"),
     merge: bool = typer.Option(False, "--merge", "-m"),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
@@ -172,6 +180,7 @@ def processes(
         simapro=simapro,
         merge=merge,
         scopes=scopes,
+        cpu_count=cpu_count,
     )
 
 

--- a/ecobalyse_data/computation.py
+++ b/ecobalyse_data/computation.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-
 import json
 import urllib.parse
+from multiprocessing import Pool
 from typing import List, Optional
 
 import bw2calc
@@ -98,7 +98,13 @@ def compute_process_for_activity(
 
 
 def compute_processes_for_activities(
-    activities: List[dict], main_method, impacts_py, impacts_json, factors, simapro=True
+    activities: List[dict],
+    main_method,
+    impacts_py,
+    impacts_json,
+    factors,
+    simapro=True,
+    cpu_count=1,
 ) -> List[Process]:
     processes: List[Process] = []
     # Dictionary to track processed activities by their name
@@ -107,9 +113,11 @@ def compute_processes_for_activities(
     index = 1
     total = len(activities)
 
+    computation_parameters = []
+
     for eco_activity in activities:
         logger.info(
-            f"-> [{index}/{total}] Getting impacts for '{eco_activity.get('displayName')}'"
+            f"-> [{index}/{total}] Preparing parameters for '{eco_activity.get('displayName')}'"
         )
         index += 1
 
@@ -135,19 +143,29 @@ def compute_processes_for_activities(
             logger.info(f"-> Skipping duplicate activity: '{activity_key}'")
             continue
 
-        process = compute_process_for_activity(
-            eco_activity,
-            bw_activity,
-            main_method,
-            impacts_py,
-            impacts_json,
-            factors,
-            simapro=False if eco_activity["source"] == "Ecobalyse" else simapro,
+        computation_parameters.append(
+            # Parameters of the `get_process_with_impacts` function
+            (
+                eco_activity,
+                bw_activity,
+                main_method,
+                impacts_py,
+                impacts_json,
+                factors,
+                False if eco_activity["source"] == "Ecobalyse" else simapro,
+            )
         )
 
-        if process:
-            processes.append(process)
-            processed_activities.add(activity_key)
+        processed_activities.add(activity_key)
+
+    if cpu_count > 1:
+        with Pool(cpu_count) as pool:
+            processes = pool.starmap(
+                compute_process_for_activity, computation_parameters
+            )
+    else:
+        for parameters in computation_parameters:
+            processes.append(compute_process_for_activity(*parameters))
 
     return processes
 

--- a/ecobalyse_data/export/process.py
+++ b/ecobalyse_data/export/process.py
@@ -29,11 +29,18 @@ def activities_to_processes(
     simapro: bool = True,
     merge: bool = False,
     scopes: list[Scope] = None,
+    cpu_count: int = 1,
 ):
     factors = get_normalization_weighting_factors(IMPACTS_JSON)
 
     processes: List[Process] = compute_processes_for_activities(
-        activities, main_method, impacts_py, IMPACTS_JSON, factors, simapro=simapro
+        activities,
+        main_method,
+        impacts_py,
+        IMPACTS_JSON,
+        factors,
+        simapro=simapro,
+        cpu_count=cpu_count,
     )
 
     index = 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -709,7 +710,7 @@ dev = [
 requires-dist = [
     { name = "bw2analyzer", specifier = "==0.11.7" },
     { name = "bw2calc", specifier = "==2.0.1" },
-    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869#1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
+    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
     { name = "bw2io", extras = ["multifunctional"], specifier = "==0.9.5" },
     { name = "bw2parameters", specifier = "==1.1.0" },
     { name = "deadcode", specifier = ">=2.4.1" },


### PR DESCRIPTION
## :wrench: Problem

Impact computation takes a lot of time because it is done sequentially.

## :cake: Solution

Use multiprocessing to parallelize the impacts computation.


## :desert_island: How to test
By default, multiprocessing is enabled and will take all your available cores minus one.

```bash
PYTHONPATH=.; uv run python ./bin/export.py processes
```

If you want to see the performance difference, you can force using only one CPU.
```
PYTHONPATH=.; uv run python ./bin/export.py processes --cpu-count 1
```
