### PR TITLE
ci: fix multiprocessing error

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -11,12 +11,7 @@ def test_export_processes(forwast, tmp_path, processes_impacts_json):
     settings.set("LOCAL_EXPORT", False)
     settings.set("BASE_PATH", "tests/fixtures")
 
-    export.processes(
-        scopes=None,
-        simapro=False,
-        plot=False,
-        verbose=False,
-    )
+    export.processes(scopes=None, simapro=False, plot=False, verbose=False, cpu_count=1)
 
     with open(os.path.join(tmp_path, "processes_impacts.json"), "rb") as f:
         json_data = orjson.loads(f.read())

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -709,7 +710,7 @@ dev = [
 requires-dist = [
     { name = "bw2analyzer", specifier = "==0.11.7" },
     { name = "bw2calc", specifier = "==2.0.1" },
-    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869#1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
+    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
     { name = "bw2io", extras = ["multifunctional"], specifier = "==0.9.5" },
     { name = "bw2parameters", specifier = "==1.1.0" },
     { name = "deadcode", specifier = ">=2.4.1" },


### PR DESCRIPTION
## :wrench: Problem

Tests are broken on `main` due to an error with multiprocessing usage in GH actions.

## :cake: Solution

Disable multiprocessing in tests.


## :rotating_light:  Points to watch/comments

`uv.lock` has been updated for latest uv version. Run `uv self update` to update uv to the latest version.

## :desert_island: How to test

Tests on CI should be green.