### PR TITLE
fix: force recomputation of land occupations 

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -2186,7 +2186,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product", "bleublanccoeur"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2207,7 +2206,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2228,7 +2226,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2247,7 +2244,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2266,7 +2262,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2285,7 +2280,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2305,7 +2299,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2324,7 +2317,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2343,7 +2335,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2364,7 +2355,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2385,7 +2375,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2415,7 +2404,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -2436,7 +2424,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2457,7 +2444,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2478,7 +2464,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2499,7 +2484,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2520,7 +2504,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2541,7 +2524,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2562,7 +2544,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2581,7 +2562,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2600,7 +2580,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2619,7 +2598,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2638,7 +2616,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2657,7 +2634,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2676,7 +2652,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2695,7 +2670,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2713,7 +2687,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Butter, 82% fat, unsalted, at dairy {FR} U",
@@ -2730,7 +2703,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Butter, 82% fat, unsalted, at dairy {FR} organic, constructed by Ecobalyse",
@@ -2927,7 +2899,6 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Tap water Europe market",
@@ -2954,7 +2925,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Comte cheese, from cow's milk, at plant {FR} U",
@@ -2972,7 +2942,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Emmental cheese, from cow's milk, at plant {FR} U",
@@ -2990,7 +2959,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Mozzarella cheese, from cow's milk, at plant {FR} U",
@@ -3009,7 +2977,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3029,7 +2996,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3048,7 +3014,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3068,7 +3033,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3087,7 +3051,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3106,7 +3069,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3125,7 +3087,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -3144,7 +3105,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -3163,7 +3123,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3181,7 +3140,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scopes": ["food"],
     "search": "Sausage meat, raw, at plant {FR} U",
@@ -3198,7 +3156,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scopes": ["food"],
     "search": "Toulouse sausage, raw, at plant {FR} U",
@@ -3215,7 +3172,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Toulouse sausage, cooked, at plant {FR} U",
@@ -3232,7 +3188,6 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Plant-based sausage with tofu (vegan), at plant {FR} U",
@@ -3250,7 +3205,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3269,7 +3223,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3290,7 +3243,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3311,7 +3263,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -3332,7 +3283,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3353,7 +3303,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3374,7 +3323,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3395,7 +3343,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -3416,7 +3363,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3437,7 +3383,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3456,7 +3401,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3475,7 +3419,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3515,7 +3458,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -3537,7 +3479,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3556,7 +3497,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3575,7 +3515,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3594,7 +3533,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3614,7 +3552,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3632,7 +3569,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Milk, powder, skimmed, non rehydrated, at plant {FR} ",
@@ -3650,7 +3586,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3668,7 +3603,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scopes": ["food"],
     "search": "Fresh shrimps, China production FR U",
@@ -3686,7 +3620,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scopes": ["food"],
     "search": "Large trout, 2-4kg, conventional, at farm gate FR U",
@@ -3706,7 +3639,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3727,7 +3659,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3748,7 +3679,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3769,7 +3699,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3788,7 +3717,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3809,7 +3737,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3830,7 +3757,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3850,7 +3776,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3869,7 +3794,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3888,7 +3812,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3907,7 +3830,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3926,7 +3848,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3945,7 +3866,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3964,7 +3884,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3983,7 +3902,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4002,7 +3920,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4021,7 +3938,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4040,7 +3956,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4060,7 +3975,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4079,7 +3993,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4098,7 +4011,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4117,7 +4029,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4136,7 +4047,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4156,7 +4066,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4175,7 +4084,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4194,7 +4102,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.398,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4214,7 +4121,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.398,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4233,7 +4139,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4253,7 +4158,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4273,7 +4177,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4292,7 +4195,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4312,7 +4214,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4332,7 +4233,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4351,7 +4251,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4371,7 +4270,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -4390,7 +4288,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4410,7 +4307,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4429,7 +4325,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4448,7 +4343,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4467,7 +4361,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4486,7 +4379,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4505,7 +4397,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4524,7 +4415,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4544,7 +4434,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4563,7 +4452,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4583,7 +4471,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4603,7 +4490,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4623,7 +4509,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4643,7 +4528,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4663,7 +4547,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4682,7 +4565,6 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4701,7 +4583,6 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4720,7 +4601,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4739,7 +4619,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4758,7 +4637,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4777,7 +4655,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4796,7 +4673,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4815,7 +4691,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4835,7 +4710,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4854,7 +4728,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4874,7 +4747,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4894,7 +4766,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4914,7 +4785,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4933,7 +4803,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4953,7 +4822,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4972,7 +4840,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4992,7 +4859,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5012,7 +4878,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5032,7 +4897,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5051,7 +4915,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5071,7 +4934,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5091,7 +4953,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5111,7 +4972,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5131,7 +4991,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5150,7 +5009,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5170,7 +5028,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5189,7 +5046,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5209,7 +5065,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5229,7 +5084,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5249,7 +5103,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5268,7 +5121,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5287,7 +5139,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5307,7 +5158,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5326,7 +5176,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5346,7 +5195,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5366,7 +5214,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5386,7 +5233,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5406,7 +5252,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5426,7 +5271,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5446,7 +5290,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5506,7 +5349,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5526,7 +5368,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5546,7 +5387,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5566,7 +5406,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5586,7 +5425,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5606,7 +5444,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5626,7 +5463,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5646,7 +5482,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5666,7 +5501,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5686,7 +5520,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5706,7 +5539,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5726,7 +5558,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5745,7 +5576,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5765,7 +5595,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5785,7 +5614,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5804,7 +5632,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5824,7 +5651,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5844,7 +5670,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5863,7 +5688,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5882,7 +5706,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -5901,7 +5724,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5921,7 +5743,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5941,7 +5762,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["organic", "vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -5961,7 +5781,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5981,7 +5800,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6001,7 +5819,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6021,7 +5838,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6040,7 +5856,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6059,7 +5874,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6078,7 +5892,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6098,7 +5911,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6118,7 +5930,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6138,7 +5949,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6158,7 +5968,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6178,7 +5987,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -6198,7 +6006,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6218,7 +6025,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6238,7 +6044,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6258,7 +6063,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -6278,7 +6082,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6298,7 +6101,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6317,7 +6119,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6336,7 +6137,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6355,7 +6155,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6374,7 +6173,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6394,7 +6192,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6414,7 +6211,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6434,7 +6230,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["organic", "vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6453,7 +6248,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6473,7 +6267,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6492,7 +6285,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6512,7 +6304,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6532,7 +6323,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6551,7 +6341,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6571,7 +6360,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6591,7 +6379,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6611,7 +6398,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6630,7 +6416,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6650,7 +6435,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6670,7 +6454,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6690,7 +6473,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6710,7 +6492,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6730,7 +6511,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6750,7 +6530,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6770,7 +6549,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6790,7 +6568,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6810,7 +6587,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6830,7 +6606,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6850,7 +6625,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6870,7 +6644,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6889,7 +6662,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6909,7 +6681,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6929,7 +6700,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6949,7 +6719,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6969,7 +6738,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6989,7 +6757,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7009,7 +6776,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7028,7 +6794,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7048,7 +6813,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7068,7 +6832,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7088,7 +6851,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7107,7 +6869,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7127,7 +6888,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7147,7 +6907,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7167,7 +6926,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7187,7 +6945,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7207,7 +6964,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7227,7 +6983,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7247,7 +7002,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7267,7 +7021,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7287,7 +7040,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7307,7 +7059,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7327,7 +7078,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7347,7 +7097,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7366,7 +7115,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -7386,7 +7134,6 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7406,7 +7153,6 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7425,7 +7171,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -7445,7 +7190,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7465,7 +7209,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7485,7 +7228,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7505,7 +7247,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7525,7 +7266,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7545,7 +7285,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7565,7 +7304,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7585,7 +7323,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7605,7 +7342,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7627,7 +7363,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7649,7 +7384,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7671,7 +7405,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7693,7 +7426,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7714,7 +7446,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7734,7 +7465,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7753,7 +7483,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7774,7 +7503,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7795,7 +7523,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7816,7 +7543,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7837,7 +7563,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7856,7 +7581,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7876,7 +7600,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7898,7 +7621,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7917,7 +7639,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7936,7 +7657,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7955,7 +7675,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7974,7 +7693,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7995,7 +7713,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8014,7 +7731,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8035,7 +7751,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8056,7 +7771,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.73,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8077,7 +7791,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8117,7 +7830,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8138,7 +7850,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8157,7 +7868,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8176,7 +7886,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8195,7 +7904,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8216,7 +7924,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8235,7 +7942,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8254,7 +7960,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8273,7 +7978,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8292,7 +7996,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8313,7 +8016,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8332,7 +8034,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8351,7 +8052,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8372,7 +8072,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8391,7 +8090,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8410,7 +8108,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8429,7 +8126,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8448,7 +8144,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8486,7 +8181,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8505,7 +8199,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8524,7 +8217,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8545,7 +8237,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -8566,7 +8257,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -8586,7 +8276,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8606,7 +8295,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8626,7 +8314,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8645,7 +8332,6 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8664,7 +8350,6 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8683,7 +8368,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8703,7 +8387,6 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8722,7 +8405,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -8741,7 +8423,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8761,7 +8442,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8780,7 +8460,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8799,7 +8478,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8819,7 +8497,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8839,7 +8516,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8858,7 +8534,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8877,7 +8552,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8896,7 +8570,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8915,7 +8588,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8934,7 +8606,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8953,7 +8624,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8972,7 +8642,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8991,7 +8660,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9010,7 +8678,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9029,7 +8696,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9048,7 +8714,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9067,7 +8732,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9088,7 +8752,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9109,7 +8772,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9128,7 +8790,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -9147,7 +8808,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -9166,7 +8826,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9185,7 +8844,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9205,7 +8863,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9223,7 +8880,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": null,
     "scopes": ["food"],
@@ -9243,7 +8899,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9264,7 +8919,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9283,7 +8937,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9301,7 +8954,6 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": null,
     "scopes": ["food"],
@@ -9323,7 +8975,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -9341,7 +8992,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scenario": null,
     "scopes": ["food"],
@@ -9361,7 +9011,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9380,7 +9029,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9398,7 +9046,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9416,7 +9063,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9434,7 +9080,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9452,7 +9097,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9470,7 +9114,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9488,7 +9131,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9506,7 +9148,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9560,7 +9201,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9649,7 +9289,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9668,7 +9307,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9687,7 +9325,6 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9707,7 +9344,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9727,7 +9363,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9747,7 +9382,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9767,7 +9401,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9787,7 +9420,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9806,7 +9438,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9825,7 +9456,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9844,7 +9474,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9863,7 +9492,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9882,7 +9510,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9902,7 +9529,6 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9921,7 +9547,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9940,7 +9565,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9959,7 +9583,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9978,7 +9601,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9997,7 +9619,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10016,7 +9637,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -10035,7 +9655,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10054,7 +9673,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10073,7 +9691,6 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10092,7 +9709,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10111,7 +9727,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10130,7 +9745,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10151,7 +9765,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -10170,7 +9783,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10190,7 +9802,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10210,7 +9821,6 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -10229,7 +9839,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10248,7 +9857,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10267,7 +9875,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10286,7 +9893,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10305,7 +9911,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10324,7 +9929,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10344,7 +9948,6 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.6195,
-
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],

--- a/activities.json
+++ b/activities.json
@@ -2186,7 +2186,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product", "bleublanccoeur"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.46758,
+
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2207,7 +2207,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.39111,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2228,7 +2228,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.75061,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2247,7 +2247,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.158662,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2266,7 +2266,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.54841,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2285,7 +2285,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.27477,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2305,7 +2305,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.86003,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2324,7 +2324,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.06903,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2343,7 +2343,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.50845,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2364,7 +2364,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 53.2807,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2385,7 +2385,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 48.1066,
+
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2415,7 +2415,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 52.4624,
+
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -2436,7 +2436,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0222858,
+
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2457,7 +2457,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.55805,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2478,7 +2478,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 24.0522,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2499,7 +2499,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.43857,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2520,7 +2520,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.03944,
+
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2541,7 +2541,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 15.8211,
+
     "rawToCookedRatio": 0.755,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2562,7 +2562,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 18.5224,
+
     "rawToCookedRatio": 0.755,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2581,7 +2581,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.48406,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2600,7 +2600,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.47375,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2619,7 +2619,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.58862,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -2638,7 +2638,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 14.3684,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2657,7 +2657,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.135212,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2676,7 +2676,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.818576,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2695,7 +2695,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.500026,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -2713,7 +2713,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.16768,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Butter, 82% fat, unsalted, at dairy {FR} U",
@@ -2730,7 +2730,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 11.5338,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Butter, 82% fat, unsalted, at dairy {FR} organic, constructed by Ecobalyse",
@@ -2927,7 +2927,7 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.10364e-5,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Tap water Europe market",
@@ -2954,7 +2954,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.30318,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Comte cheese, from cow's milk, at plant {FR} U",
@@ -2972,7 +2972,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.64095,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Emmental cheese, from cow's milk, at plant {FR} U",
@@ -2990,7 +2990,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.78392,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Mozzarella cheese, from cow's milk, at plant {FR} U",
@@ -3009,7 +3009,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.158662,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3029,7 +3029,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.158662,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3048,7 +3048,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.158662,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3068,7 +3068,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.36264,
+
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3087,7 +3087,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 4.01934,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3106,7 +3106,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.62729,
+
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3125,7 +3125,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.47554,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -3144,7 +3144,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.83451,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -3163,7 +3163,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 4.02094,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3181,7 +3181,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.3484,
+
     "rawToCookedRatio": 0.792,
     "scopes": ["food"],
     "search": "Sausage meat, raw, at plant {FR} U",
@@ -3198,7 +3198,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 19.3275,
+
     "rawToCookedRatio": 0.792,
     "scopes": ["food"],
     "search": "Toulouse sausage, raw, at plant {FR} U",
@@ -3215,7 +3215,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 19.4331,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Toulouse sausage, cooked, at plant {FR} U",
@@ -3232,7 +3232,7 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.68537,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Plant-based sausage with tofu (vegan), at plant {FR} U",
@@ -3250,7 +3250,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.436515,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3269,7 +3269,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.839183,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3290,7 +3290,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 34.7318,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3311,7 +3311,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 34.2527,
+
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -3332,7 +3332,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 36.4628,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3353,7 +3353,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 35.8645,
+
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3374,7 +3374,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 43.416,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3395,7 +3395,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 42.8171,
+
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -3416,7 +3416,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 45.5798,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3437,7 +3437,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 39.1986,
+
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3456,7 +3456,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 3.78717,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3475,7 +3475,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.455466,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3493,7 +3493,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 11.7952,
+    "landOccupation": 11.8,
     "rawToCookedRatio": 1.0,
     "scenario": null,
     "scopes": ["food"],
@@ -3515,7 +3515,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.35109,
+
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -3537,7 +3537,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.29787,
+
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3556,7 +3556,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.54198,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3575,7 +3575,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.39111,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3594,7 +3594,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-    "landOccupation": 11.6771,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3614,7 +3614,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-    "landOccupation": 16.0709,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -3632,7 +3632,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 21.5307,
+
     "rawToCookedRatio": 1.0,
     "scopes": ["food"],
     "search": "Milk, powder, skimmed, non rehydrated, at plant {FR} ",
@@ -3650,7 +3650,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.73209,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3668,7 +3668,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.85501,
+
     "rawToCookedRatio": 0.819,
     "scopes": ["food"],
     "search": "Fresh shrimps, China production FR U",
@@ -3686,7 +3686,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.55082,
+
     "rawToCookedRatio": 0.819,
     "scopes": ["food"],
     "search": "Large trout, 2-4kg, conventional, at farm gate FR U",
@@ -3706,7 +3706,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.7181,
+
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3727,7 +3727,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.06958,
+
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3748,7 +3748,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.26847,
+
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3769,7 +3769,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.77893,
+
     "rawToCookedRatio": 0.974,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3788,7 +3788,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.03268,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3809,7 +3809,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 96.5479,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3830,7 +3830,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 206.08,
+
     "rawToCookedRatio": 0.792,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3850,7 +3850,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.382069,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -3869,7 +3869,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.123336,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3888,7 +3888,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.180271,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3907,7 +3907,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.287541,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3921,12 +3921,12 @@
     "categories": ["ingredient"],
     "cropGroup": "LEGUMES-FLEURS",
     "defaultOrigin": "France",
-    "displayName": "Courgette FR",
+    "displayName": "11.8,Courgette FR",
     "id": "a8ba3467-3c82-442a-a73a-98769061b7a9",
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.0976558,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3945,7 +3945,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.228955,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -3964,7 +3964,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.240222,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -3983,7 +3983,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.264092,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4002,7 +4002,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.476767,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4021,7 +4021,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.46046,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4040,7 +4040,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.424512,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4060,7 +4060,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.424512,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4079,7 +4079,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.289256,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4098,7 +4098,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.289262,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4117,7 +4117,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.79665,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4136,7 +4136,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.26,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4156,7 +4156,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.21575,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4175,7 +4175,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.243671,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4194,7 +4194,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.398,
-    "landOccupation": 0.0976558,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4214,7 +4214,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.398,
-    "landOccupation": 0.0976558,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4233,7 +4233,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-    "landOccupation": 1.33556,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4253,7 +4253,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-    "landOccupation": 1.33556,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4273,7 +4273,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.271,
-    "landOccupation": 1.33556,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4292,7 +4292,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.10889,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4312,7 +4312,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0918483,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4332,7 +4332,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0918483,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4351,7 +4351,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.38,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4371,7 +4371,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.38,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -4390,7 +4390,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 14.06,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4410,7 +4410,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.27999,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4429,7 +4429,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 14.06,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4448,7 +4448,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.0976558,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4467,7 +4467,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.228955,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4486,7 +4486,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.135498,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4505,7 +4505,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.04,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4524,7 +4524,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.06,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4544,7 +4544,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.089318,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4563,7 +4563,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.591809,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4583,7 +4583,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.591809,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4603,7 +4603,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 8.1,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4623,7 +4623,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 7.05424,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4643,7 +4643,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 14.1135,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4663,7 +4663,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 16.2036,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -4682,7 +4682,7 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.445121,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4701,7 +4701,7 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.77214,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4720,7 +4720,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.673652,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4739,7 +4739,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4758,7 +4758,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.172918,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4777,7 +4777,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.123336,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4796,7 +4796,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.123336,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4815,7 +4815,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.180271,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4835,7 +4835,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.287541,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4854,7 +4854,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4874,7 +4874,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.77214,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4894,7 +4894,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.103602,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4914,7 +4914,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4933,7 +4933,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.673652,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -4953,7 +4953,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.11,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -4972,7 +4972,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.26,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -4992,7 +4992,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.34941,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5012,7 +5012,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.270831,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5032,7 +5032,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 2.02685,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5051,7 +5051,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.6333,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5071,7 +5071,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.11924,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5091,7 +5091,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.36502,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5111,7 +5111,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.7502,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5131,7 +5131,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 11.3485,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5150,7 +5150,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 12.03,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5170,7 +5170,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 1.01943,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5189,7 +5189,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.79,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5209,7 +5209,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.77,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5229,7 +5229,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.124,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5249,7 +5249,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.49449,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -5268,7 +5268,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.962105,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5287,7 +5287,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.317808,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5307,7 +5307,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.317808,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5326,7 +5326,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.41,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5346,7 +5346,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.05,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5366,7 +5366,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.158812,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5386,7 +5386,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.158812,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5406,7 +5406,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.117091,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5426,7 +5426,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.45,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5446,7 +5446,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 2.03,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5466,7 +5466,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.95167,
+    "landOccupation": 1.95,
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5486,7 +5486,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.26885,
+    "landOccupation": 1.27,
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5506,7 +5506,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.347772,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5526,7 +5526,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.275997,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5546,7 +5546,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.06,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5566,7 +5566,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.225361,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5586,7 +5586,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.225361,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5606,7 +5606,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.638086,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5626,7 +5626,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.08214,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5646,7 +5646,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.13833,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5666,7 +5666,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.13833,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5686,7 +5686,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.123336,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5706,7 +5706,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.180271,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5726,7 +5726,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.287541,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5745,7 +5745,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.53,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5765,7 +5765,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.16222,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5785,7 +5785,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.16222,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5804,7 +5804,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.13,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5824,7 +5824,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.344427,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5844,7 +5844,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.51,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -5863,7 +5863,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5882,7 +5882,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.673652,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -5901,7 +5901,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.98439,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5921,7 +5921,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5941,7 +5941,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["organic", "vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.673652,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -5961,7 +5961,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.228955,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -5981,7 +5981,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.531675,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6001,7 +6001,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.10889,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6021,7 +6021,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0918483,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6040,7 +6040,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.08196,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6059,7 +6059,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.10889,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6078,7 +6078,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0918483,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6098,7 +6098,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 0.953,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6118,7 +6118,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.46404,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6138,7 +6138,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.25698,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6158,7 +6158,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.238316,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6178,7 +6178,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.8,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -6198,7 +6198,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.8,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6218,7 +6218,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0462044,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6238,7 +6238,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.05,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6258,7 +6258,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.8,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -6278,7 +6278,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.8,
+
     "rawToCookedRatio": 2.33,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6298,7 +6298,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.21,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6317,7 +6317,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.63342,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6336,7 +6336,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.19,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6355,7 +6355,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.7526,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6374,7 +6374,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.01,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6394,7 +6394,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 3.52234,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6414,7 +6414,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 3.37552,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6434,7 +6434,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["organic", "vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.38,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6453,7 +6453,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.38,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6473,7 +6473,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.472212,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6492,7 +6492,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.470272,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6512,7 +6512,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.605803,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6532,7 +6532,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.13122,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6551,7 +6551,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0761094,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6571,7 +6571,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.173983,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6591,7 +6591,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.0273869,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6611,7 +6611,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.271833,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6630,7 +6630,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 4.73249,
+
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6650,7 +6650,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.67836,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6670,7 +6670,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0313593,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6690,7 +6690,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.836863,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6710,7 +6710,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.836863,
+    "landOccupation": 
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6730,7 +6730,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.78732,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -6750,7 +6750,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.75867,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -6770,7 +6770,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.36763,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6790,7 +6790,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.49649,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -6810,7 +6810,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.8946,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6830,7 +6830,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.50719,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6850,7 +6850,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.37137,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6870,7 +6870,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.301111,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6889,7 +6889,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.135,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6909,7 +6909,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.63165,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6929,7 +6929,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.22988,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6949,7 +6949,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.22853,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6969,7 +6969,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0313593,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -6989,7 +6989,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0313593,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7009,7 +7009,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.58113,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7028,7 +7028,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.284007,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7048,7 +7048,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.40676,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7068,7 +7068,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.16642,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7088,7 +7088,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.82296,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7107,7 +7107,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw", "organic"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.50418,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7127,7 +7127,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.03285,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7147,7 +7147,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 7.95448,
+
     "rawToCookedRatio": 2.33,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7167,7 +7167,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.701477,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7187,7 +7187,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.142965,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7207,7 +7207,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 25.4923,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7227,7 +7227,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 25.4923,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7247,7 +7247,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.284007,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7267,7 +7267,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.33367,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7287,7 +7287,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0469125,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7307,7 +7307,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.527097,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7327,7 +7327,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 0.893299,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7347,7 +7347,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 0.893299,
+
     "rawToCookedRatio": 2.259,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7366,7 +7366,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.9659,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -7386,7 +7386,7 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.0,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7406,7 +7406,7 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.0,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7425,7 +7425,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.78732,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -7445,7 +7445,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 2.13557,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7465,7 +7465,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 13.976,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7485,7 +7485,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 1.25331,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7505,7 +7505,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 7.45491,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7525,7 +7525,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 28.7167,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7545,7 +7545,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 15.0431,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7565,7 +7565,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 10.4129,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7585,7 +7585,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 4.7043,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7605,7 +7605,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 11.5458,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7627,7 +7627,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.09036,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7649,7 +7649,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.69576,
+
     "rawToCookedRatio": 0.974,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7671,7 +7671,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.70244,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7693,7 +7693,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.70299,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7714,7 +7714,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.67983,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7734,7 +7734,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 11.9277,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7753,7 +7753,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0304003,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7774,7 +7774,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.00414,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7795,7 +7795,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.09964,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7816,7 +7816,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.94777,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7837,7 +7837,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 25.7743,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -7856,7 +7856,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.26874,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -7876,7 +7876,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.388281,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7898,7 +7898,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.93317,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7917,7 +7917,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.44156,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7936,7 +7936,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.84961,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7955,7 +7955,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.266929,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7974,7 +7974,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.11922,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -7995,7 +7995,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 17.5838,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8014,7 +8014,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.984574,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8035,7 +8035,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 4.84218,
+
     "rawToCookedRatio": 0.755,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8056,7 +8056,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.65073,
+
     "rawToCookedRatio": 0.73,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8077,7 +8077,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0558186,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8096,7 +8096,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 2.39353,
+    "landOccupation": 2.39,
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8117,7 +8117,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 12.1959,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8138,7 +8138,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.2816,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8157,7 +8157,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 19.8412,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8176,7 +8176,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 2.65457,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8195,7 +8195,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.0896314,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8216,7 +8216,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 21.4548,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8235,7 +8235,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.302252,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8254,7 +8254,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.80742,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8273,7 +8273,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 0.24,
-    "landOccupation": 4.36205,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8292,7 +8292,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.41808,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8313,7 +8313,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.58135,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8332,7 +8332,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["spice_condiment_additive"],
     "ingredientDensity": 1.0,
-    "landOccupation": 16.0846,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8351,7 +8351,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.476288,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8372,7 +8372,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.69807,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8391,7 +8391,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.382579,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8410,7 +8410,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.558437,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8429,7 +8429,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.319645,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8448,7 +8448,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.422115,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8467,7 +8467,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.37966,
+    "landOccupation": 1.38,
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8486,7 +8486,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.217924,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8505,7 +8505,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.447,
-    "landOccupation": 2.02553,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8524,7 +8524,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.566708,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8545,7 +8545,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 10.6309,
+
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -8566,7 +8566,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 7.39752,
+
     "rawToCookedRatio": 0.792,
     "scenario": "import",
     "scopes": ["food"],
@@ -8586,7 +8586,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.53274,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8606,7 +8606,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.53274,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8626,7 +8626,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 3.53274,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -8645,7 +8645,7 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.445121,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8664,7 +8664,7 @@
     "inediblePart": 0.6,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.445121,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8683,7 +8683,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 1.02238,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8703,7 +8703,7 @@
     "inediblePart": 0.3,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 1.01943,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8722,7 +8722,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.76034,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -8741,7 +8741,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0492245,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8761,7 +8761,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0462044,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8780,7 +8780,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.218137,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8799,7 +8799,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.118895,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8819,7 +8819,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.2355,
-    "landOccupation": 0.117091,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8839,7 +8839,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.13833,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8858,7 +8858,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.55971,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8877,7 +8877,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.51223,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8896,7 +8896,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 11.1112,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8915,7 +8915,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.103602,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8934,7 +8934,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.103602,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -8953,7 +8953,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh", "organic"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.138206,
+
     "rawToCookedRatio": 0.856,
     "scenario": "organic",
     "scopes": ["food"],
@@ -8972,7 +8972,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -8991,7 +8991,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9010,7 +9010,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9029,7 +9029,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.362,
-    "landOccupation": 0.461938,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9048,7 +9048,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 0,
-    "landOccupation": 2.15732,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9067,7 +9067,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 5.12764,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9088,7 +9088,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.537985,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9109,7 +9109,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.87209,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9128,7 +9128,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.98439,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -9147,7 +9147,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.98439,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -9166,7 +9166,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.118,
-    "landOccupation": 0.0918483,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9185,7 +9185,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 0.237212,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9205,7 +9205,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.124,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9223,7 +9223,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["dairy_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.16768,
+
     "rawToCookedRatio": 1.0,
     "scenario": null,
     "scopes": ["food"],
@@ -9243,7 +9243,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 0.531675,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9264,7 +9264,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 43.416,
+
     "rawToCookedRatio": 0.792,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9283,7 +9283,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["misc"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.39111,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9301,7 +9301,7 @@
     "inediblePart": 0,
     "ingredientCategories": [],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.10364e-5,
+
     "rawToCookedRatio": 1.0,
     "scenario": null,
     "scopes": ["food"],
@@ -9323,7 +9323,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 9.35109,
+
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -9341,7 +9341,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.85501,
+
     "rawToCookedRatio": 0.819,
     "scenario": null,
     "scopes": ["food"],
@@ -9361,7 +9361,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 16.2036,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9380,7 +9380,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["nut_oilseed_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.58862,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9398,7 +9398,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0339743,
+
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9416,7 +9416,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0339743,
+
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9434,7 +9434,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0339743,
+
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9452,7 +9452,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.00403671,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9470,7 +9470,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0162783,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9488,7 +9488,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.00403671,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9506,7 +9506,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0342705,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9524,7 +9524,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.328836,
+    "landOccupation": 0.329,
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9542,7 +9542,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.62051,
+    "landOccupation": 0.621,
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9560,7 +9560,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0238428,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9578,7 +9578,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.83983,
+    "landOccupation": 1.84,
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9596,7 +9596,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.83215,
+    "landOccupation": 1.83,
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9614,7 +9614,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.125442,
+    "landOccupation": 0.125,
     "rawToCookedRatio": 0.819,
     "scenario": "import",
     "scopes": ["food"],
@@ -9632,7 +9632,6 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 629.095,
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9650,7 +9649,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0342705,
+
     "rawToCookedRatio": 0.819,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9669,7 +9668,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.575,
-    "landOccupation": 1.2835,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9688,7 +9687,7 @@
     "inediblePart": 0.4,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.0766257,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9708,7 +9707,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.45,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9728,7 +9727,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 3.45,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9748,7 +9747,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 12.7862,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9768,7 +9767,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 27.4528,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9788,7 +9787,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 15.7975,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9807,7 +9806,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw", "organic"],
     "ingredientDensity": 0.24,
-    "landOccupation": 12.8837,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9826,7 +9825,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.53,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9845,7 +9844,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 6.53,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -9864,7 +9863,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.35883,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9883,7 +9882,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 1.35913,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9903,7 +9902,7 @@
     "inediblePart": 0.5,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 5.61721,
+
     "rawToCookedRatio": 1.0,
     "scenario": "organic",
     "scopes": ["food"],
@@ -9922,7 +9921,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.174722,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9941,7 +9940,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 0.174722,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -9960,7 +9959,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.2368,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -9979,7 +9978,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 8.2368,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -9998,7 +9997,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.34737,
+
     "rawToCookedRatio": 2.259,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10017,7 +10016,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["nut_oilseed_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.23981,
+
     "rawToCookedRatio": 2.33,
     "scenario": "import",
     "scopes": ["food"],
@@ -10036,7 +10035,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-    "landOccupation": 0.0807367,
+
     "rawToCookedRatio": 0.856,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10055,7 +10054,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-    "landOccupation": 0.0807367,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10074,7 +10073,7 @@
     "inediblePart": 0.03,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.295,
-    "landOccupation": 0.0807367,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10093,7 +10092,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 0.78076,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10112,7 +10111,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.24724,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10131,7 +10130,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.620121,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10152,7 +10151,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["animal_product"],
     "ingredientDensity": 1.0,
-    "landOccupation": 6.89045,
+
     "rawToCookedRatio": 0.755,
     "scenario": "import",
     "scopes": ["food"],
@@ -10171,7 +10170,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 1.0,
-    "landOccupation": 0.0677044,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10191,7 +10190,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.0461652,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],
@@ -10211,7 +10210,7 @@
     "inediblePart": 0.1,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.6375,
-    "landOccupation": 0.0443612,
+
     "rawToCookedRatio": 1.0,
     "scenario": "import",
     "scopes": ["food"],
@@ -10230,7 +10229,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 0.24,
-    "landOccupation": 1.21333,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10249,7 +10248,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 3.79749,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10268,7 +10267,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_processed"],
     "ingredientDensity": 0.24,
-    "landOccupation": 3.79749,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10287,7 +10286,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.49183,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10306,7 +10305,7 @@
     "inediblePart": 0.2,
     "ingredientCategories": ["vegetable_fresh"],
     "ingredientDensity": 0.447,
-    "landOccupation": 1.25571,
+
     "rawToCookedRatio": 0.856,
     "scenario": "import",
     "scopes": ["food"],
@@ -10325,7 +10324,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["grain_raw"],
     "ingredientDensity": 1.0,
-    "landOccupation": 2.7526,
+
     "rawToCookedRatio": 2.259,
     "scenario": "import",
     "scopes": ["food"],
@@ -10345,7 +10344,7 @@
     "inediblePart": 0,
     "ingredientCategories": ["vegetable_processed"],
     "ingredientDensity": 0.6195,
-    "landOccupation": 2.51149,
+
     "rawToCookedRatio": 1.0,
     "scenario": "reference",
     "scopes": ["food"],

--- a/public/data/food/ingredients.json
+++ b/public/data/food/ingredients.json
@@ -5,15 +5,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 10.6039,
-      "hedges": 1.87477,
+      "cropDiversity": 10.6043,
+      "hedges": 1.87486,
       "livestockDensity": -0.007728,
       "permanentPasture": 0,
-      "plotSize": 2.49877
+      "plotSize": 2.49886
     },
     "id": "7ef7399a-1d56-4947-b773-9f6438a50fda",
     "inediblePart": 0.2,
-    "landOccupation": 4.46758,
+    "landOccupation": 4.46911,
     "name": "Oeuf Bleu-Blanc-Cœur FR",
     "processId": "58c49ef8-f390-5c81-83b2-8f398b64001a",
     "rawToCookedRatio": 0.974,
@@ -29,14 +29,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.670247,
+      "hedges": 0.898901,
       "livestockDensity": -0.00017,
       "permanentPasture": 0.175,
-      "plotSize": 0.631999
+      "plotSize": 0.839142
     },
     "id": "8f3863e7-f981-4367-90a2-e1aaa096a6e0",
     "inediblePart": 0,
-    "landOccupation": 1.39111,
+    "landOccupation": 1.39148,
     "name": "Lait FR",
     "processId": "0427c659-7389-5087-b9f1-d7a4369fe7f6",
     "rawToCookedRatio": 1.0,
@@ -51,15 +51,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 0.545818,
-      "hedges": 1.23278,
+      "cropDiversity": 0.545838,
+      "hedges": 1.68909,
       "livestockDensity": -0.000178,
       "permanentPasture": 0.814,
-      "plotSize": 1.11351
+      "plotSize": 1.51092
     },
     "id": "2bf307e8-8cb0-400b-a4f1-cf615d9e96f4",
     "inediblePart": 0,
-    "landOccupation": 1.75061,
+    "landOccupation": 1.75076,
     "name": "Lait Bio",
     "processId": "fdd912e1-6622-589a-808c-12a2bcf50efe",
     "rawToCookedRatio": 1.0,
@@ -75,13 +75,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 0.44441,
-      "hedges": 0.091797,
-      "plotSize": 0.13883
+      "cropDiversity": 0.61492,
+      "hedges": 0.12702,
+      "plotSize": 0.19209
     },
     "id": "9042b6d0-c309-4757-a03f-ba802f0c8c01",
     "inediblePart": 0.1,
-    "landOccupation": 0.158662,
+    "landOccupation": 0.219535,
     "name": "Carotte Bio",
     "processId": "9a31a1e4-c536-5307-aea5-bf4364c2f15d",
     "rawToCookedRatio": 0.856,
@@ -98,12 +98,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.43134,
-      "plotSize": 0.58065
+      "hedges": 0.43142,
+      "plotSize": 0.58076
     },
     "id": "a2e25aca-1f42-4bc8-bc0e-4d7c751775aa",
     "inediblePart": 0,
-    "landOccupation": 1.54841,
+    "landOccupation": 1.5487,
     "name": "Farine UE",
     "processId": "e9784d81-fcae-5fc2-8b5b-1166a7e0df9d",
     "rawToCookedRatio": 1.0,
@@ -119,13 +119,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 7.8594,
-      "hedges": 1.0994,
-      "plotSize": 1.6374
+      "cropDiversity": 7.86,
+      "hedges": 1.0995,
+      "plotSize": 1.6375
     },
     "id": "db791ac8-02b9-41b0-bc2b-2913e745bd19",
     "inediblePart": 0,
-    "landOccupation": 3.27477,
+    "landOccupation": 3.27502,
     "name": "Farine Bio",
     "processId": "ad6a0c77-49f4-5e61-ac4b-658624d23368",
     "rawToCookedRatio": 1.0,
@@ -141,13 +141,13 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 20.721,
-      "hedges": 2.2603,
-      "plotSize": 2.1975
+      "cropDiversity": 19.94,
+      "hedges": 2.1751,
+      "plotSize": 2.1147
     },
     "id": "dbcc6b38-8309-4bb0-a66e-525ec9dcc79c",
     "inediblePart": 0,
-    "landOccupation": 5.86003,
+    "landOccupation": 5.63909,
     "name": "Tournesol Bio",
     "processId": "92364220-c4ea-526a-9362-a873618d87bf",
     "rawToCookedRatio": 1.0,
@@ -163,13 +163,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 21.46,
-      "hedges": 2.3409,
-      "plotSize": 2.2759
+      "cropDiversity": 21.461,
+      "hedges": 2.341,
+      "plotSize": 2.276
     },
     "id": "c5dfca39-14f6-4d7c-a506-d8a5e65256a7",
     "inediblePart": 0,
-    "landOccupation": 6.06903,
+    "landOccupation": 6.06923,
     "name": "Tournesol Bio",
     "processId": "02f413a2-0287-5ee9-bcb7-2d6cc6671def",
     "rawToCookedRatio": 1.0,
@@ -185,13 +185,13 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 10.937,
-      "hedges": 1.8034,
-      "plotSize": 2.2542
+      "cropDiversity": 10.938,
+      "hedges": 1.8035,
+      "plotSize": 2.2543
     },
     "id": "5238ba53-56e4-404e-ad68-43d80a5df85b",
     "inediblePart": 0,
-    "landOccupation": 4.50845,
+    "landOccupation": 4.50865,
     "name": "Colza Bio",
     "processId": "e7ebe11b-70c6-5455-bf83-337b190b74c3",
     "rawToCookedRatio": 1.0,
@@ -207,14 +207,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 34.6779,
+      "hedges": 46.9842,
       "livestockDensity": -0.00255,
       "permanentPasture": 37.5,
-      "plotSize": 29.3193
+      "plotSize": 39.6215
     },
     "id": "41d65ed4-230f-4a47-a67c-9a8015f50420",
     "inediblePart": 0,
-    "landOccupation": 53.2807,
+    "landOccupation": 53.2876,
     "name": "Boeuf haché cru FR",
     "processId": "9a4c4a03-7244-5dd0-a669-e49452291dbd",
     "rawToCookedRatio": 0.792,
@@ -229,15 +229,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 14.9815,
-      "hedges": 39.6806,
+      "cropDiversity": 14.9822,
+      "hedges": 53.3171,
       "livestockDensity": -0.00267,
       "permanentPasture": 34.68,
-      "plotSize": 35.2595
+      "plotSize": 46.8446
     },
     "id": "4e3009f3-1b33-41d7-b6f3-dc7230331da0",
     "inediblePart": 0,
-    "landOccupation": 48.1066,
+    "landOccupation": 55.0185,
     "name": "Boeuf haché cru Bio",
     "processId": "d0ef6f4d-3590-56cc-9b42-4e4864efec35",
     "rawToCookedRatio": 0.792,
@@ -260,7 +260,7 @@
     },
     "id": "ce073919-1aff-4892-a1f5-b25ee94bccd8",
     "inediblePart": 0,
-    "landOccupation": 52.4624,
+    "landOccupation": 52.5467,
     "name": "Boeuf haché cru par défaut",
     "processId": "8b36619b-d499-5e7d-a881-b266f06a4a1c",
     "rawToCookedRatio": 0.792,
@@ -276,14 +276,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 38.8947,
+      "hedges": 52.7475,
       "livestockDensity": -0.00267,
       "permanentPasture": 50.89,
-      "plotSize": 31.8062
+      "plotSize": 43.1349
     },
     "id": "3fd1b6d5-58d9-40eb-b215-d2e8c2876a5f",
     "inediblePart": 0,
-    "landOccupation": 0.0222858,
+    "landOccupation": 55.9361,
     "name": "Boeuf haché cru - v. de réforme 100% herbe FR",
     "processId": "df3e508c-e6d8-53d1-b123-22b093ec3a59",
     "rawToCookedRatio": 0.792,
@@ -299,14 +299,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.42325,
+      "hedges": 1.52795,
       "livestockDensity": -0.027132,
       "permanentPasture": 0,
-      "plotSize": 1.83158
+      "plotSize": 1.97251
     },
     "id": "755225f1-f0c5-497f-b8a9-263828a84a22",
     "inediblePart": 0,
-    "landOccupation": 6.55805,
+    "landOccupation": 6.56426,
     "name": "Jambon cuit FR",
     "processId": "9d299fee-9b86-5500-9fc1-6dc73c88391f",
     "rawToCookedRatio": 1.0,
@@ -321,15 +321,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 35.1791,
-      "hedges": 7.61294,
+      "cropDiversity": 35.1802,
+      "hedges": 7.61336,
       "livestockDensity": -0.007803,
       "permanentPasture": 0,
-      "plotSize": 9.77094
+      "plotSize": 9.77126
     },
     "id": "4de5e41e-3271-4489-aa27-a973e4045082",
     "inediblePart": 0,
-    "landOccupation": 24.0522,
+    "landOccupation": 24.0584,
     "name": "Jambon cuit Bio",
     "processId": "226b55a7-053b-5a94-8223-b658c4d2c921",
     "rawToCookedRatio": 1.0,
@@ -345,14 +345,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.84898,
+      "hedges": 1.94852,
       "livestockDensity": -0.027132,
       "permanentPasture": 0,
-      "plotSize": 2.51282
+      "plotSize": 2.64678
     },
     "id": "15e2dfa0-9b5f-4bc9-a3ed-885f56061bc0",
     "inediblePart": 0,
-    "landOccupation": 7.43857,
+    "landOccupation": 7.44401,
     "name": "Jambon cuit (alim. ani. 100%FR) FR",
     "processId": "8540e40e-b972-5c7d-9deb-ef0eb1de3b8e",
     "rawToCookedRatio": 1.0,
@@ -368,14 +368,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.62202,
+      "hedges": 1.67159,
       "livestockDensity": -0.01518,
       "permanentPasture": 0,
-      "plotSize": 1.94246
+      "plotSize": 2.00914
     },
     "id": "a360871c-fc35-4cb3-af2c-5eeb8bd6f984",
     "inediblePart": 0,
-    "landOccupation": 6.03944,
+    "landOccupation": 6.11263,
     "name": "Blanc de poulet cru FR",
     "processId": "ccf36c8b-0777-5d41-ae20-165f2b093fa7",
     "rawToCookedRatio": 0.755,
@@ -390,15 +390,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 24.2724,
-      "hedges": 4.97894,
+      "cropDiversity": 24.2736,
+      "hedges": 4.97927,
       "livestockDensity": -0.005225,
       "permanentPasture": 0,
-      "plotSize": 5.2838
+      "plotSize": 5.28421
     },
     "id": "b19b0dc0-3478-46a0-b8a1-3225ea939ff1",
     "inediblePart": 0,
-    "landOccupation": 15.8211,
+    "landOccupation": 15.8937,
     "name": "Blanc de poulet cru Bio",
     "processId": "9b13e85c-1194-521a-83a1-aa60f2347808",
     "rawToCookedRatio": 0.755,
@@ -413,15 +413,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 24.2724,
-      "hedges": 4.97894,
+      "cropDiversity": 24.2736,
+      "hedges": 4.97927,
       "livestockDensity": -0.005225,
       "permanentPasture": 0,
-      "plotSize": 5.2838
+      "plotSize": 5.28421
     },
     "id": "b682ae30-9df9-4385-9005-4b4725c70d54",
     "inediblePart": 0,
-    "landOccupation": 18.5224,
+    "landOccupation": 18.594,
     "name": "Blanc de poulet cru (alim. ani. 100%FR) Bio",
     "processId": "cd6c4a6e-165d-5403-a1a1-baab26dfade6",
     "rawToCookedRatio": 0.755,
@@ -438,12 +438,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.9392,
-      "plotSize": 2.121
+      "hedges": 1.9397,
+      "plotSize": 2.1215
     },
     "id": "96b301d9-d21b-4cea-8903-bd7917e95a30",
     "inediblePart": 0,
-    "landOccupation": 8.48406,
+    "landOccupation": 8.48614,
     "name": "Huile de colza par défaut",
     "processId": "a08bb4c0-5480-51ff-9d9c-c7cedf0f4334",
     "rawToCookedRatio": 1.0,
@@ -459,13 +459,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 18.131,
-      "hedges": 2.9895,
-      "plotSize": 3.7369
+      "cropDiversity": 18.133,
+      "hedges": 2.9899,
+      "plotSize": 3.7373
     },
     "id": "51f8e8d2-13c0-446c-bf0a-9272fc46edde",
     "inediblePart": 0,
-    "landOccupation": 7.47375,
+    "landOccupation": 7.47465,
     "name": "Huile de colza Bio",
     "processId": "fd89d8e6-003c-5c5f-9ac6-e7acfcd861da",
     "rawToCookedRatio": 1.0,
@@ -481,13 +481,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 3.4612,
-      "hedges": 2.4539,
-      "plotSize": 3.2207
+      "cropDiversity": 3.4636,
+      "hedges": 2.4556,
+      "plotSize": 3.223
     },
     "id": "3cfab110-363e-442a-9170-1af337fe9ea3",
     "inediblePart": 0,
-    "landOccupation": 8.58862,
+    "landOccupation": 8.59466,
     "name": "Huile de tournesol par défaut",
     "processId": "c7984a1c-66cb-52ea-bb54-763e0da8ecad",
     "rawToCookedRatio": 1.0,
@@ -503,13 +503,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 50.807,
-      "hedges": 5.5421,
-      "plotSize": 5.3881
+      "cropDiversity": 50.825,
+      "hedges": 5.5441,
+      "plotSize": 5.3901
     },
     "id": "64fb23f2-0cac-403c-bbfa-1973c9a0ea40",
     "inediblePart": 0,
-    "landOccupation": 14.3684,
+    "landOccupation": 14.3735,
     "name": "Huile de tournesol Bio",
     "processId": "9665c8e8-bbf6-5a94-abe0-b080ec222011",
     "rawToCookedRatio": 1.0,
@@ -525,13 +525,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.37873,
-      "hedges": 0.07823,
-      "plotSize": 0.11831
+      "cropDiversity": 0.37941,
+      "hedges": 0.07837,
+      "plotSize": 0.11852
     },
     "id": "59092383-9bfb-419e-ab63-825c8e6e6ed0",
     "inediblePart": 0.1,
-    "landOccupation": 0.135212,
+    "landOccupation": 0.135454,
     "name": "Courgette Bio",
     "processId": "30b69d8c-c7e7-53b5-8317-9a00f3330526",
     "rawToCookedRatio": 0.856,
@@ -547,13 +547,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.51407,
-      "hedges": 0.5847,
-      "plotSize": 0.71625
+      "cropDiversity": 0.5142,
+      "hedges": 0.58485,
+      "plotSize": 0.71645
     },
     "id": "3cc14fbe-c798-46bf-bc7d-94d5ed28fa7c",
     "inediblePart": 0.2,
-    "landOccupation": 0.818576,
+    "landOccupation": 0.818796,
     "name": "Pêche Bio",
     "processId": "a749eb68-1877-53d1-a3ec-56876a532c86",
     "rawToCookedRatio": 0.856,
@@ -569,13 +569,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 1.4006,
-      "hedges": 0.2893,
-      "plotSize": 0.43752
+      "cropDiversity": 1.4011,
+      "hedges": 0.28942,
+      "plotSize": 0.4377
     },
     "id": "359ec82d-4f28-43bd-b5be-84256a45c03e",
     "inediblePart": 0.4,
-    "landOccupation": 0.500026,
+    "landOccupation": 0.500229,
     "name": "Melon Bio",
     "processId": "fb5b55ec-aab1-50df-bec5-97caef5fdd91",
     "rawToCookedRatio": 0.856,
@@ -591,7 +591,7 @@
     "density": 1.0,
     "id": "bbda834e-1548-4682-a461-c367dc1ce517",
     "inediblePart": 0,
-    "landOccupation": 9.16768,
+    "landOccupation": 9.17058,
     "name": "Beurre FR",
     "processId": "7e0e3538-e229-556b-b5ce-b69cfa9e1880",
     "rawToCookedRatio": 1.0,
@@ -606,7 +606,7 @@
     "density": 1.0,
     "id": "aeedb0fa-81a7-4f21-9bf1-7ec9c4c69ed9",
     "inediblePart": 0,
-    "landOccupation": 11.5338,
+    "landOccupation": 11.5352,
     "name": "Beurre Bio",
     "processId": "0fd6110c-4fa8-5065-8518-9f0064380669",
     "rawToCookedRatio": 1.0,
@@ -621,7 +621,7 @@
     "density": 1.0,
     "id": "36b3ffec-51e7-4e26-b1b5-7d52554e0aa6",
     "inediblePart": 0,
-    "landOccupation": 2.10364e-5,
+    "landOccupation": 2.22964e-5,
     "name": "Eau du robinet UE",
     "processId": "d3fc19a4-7ace-5870-aeb3-fe35a8189d94",
     "rawToCookedRatio": 1.0,
@@ -636,7 +636,7 @@
     "density": 1.0,
     "id": "f804033a-fe59-4ec5-b24b-c7482b2a6cf6",
     "inediblePart": 0,
-    "landOccupation": 6.30318,
+    "landOccupation": 6.30564,
     "name": "Comté FR AOP",
     "processId": "854e941b-c9dc-5e9e-92eb-68dc5cc5ff4c",
     "rawToCookedRatio": 1.0,
@@ -651,7 +651,7 @@
     "density": 1.0,
     "id": "74314f2e-aa88-4ac1-aa78-bb29dceebf0b",
     "inediblePart": 0,
-    "landOccupation": 6.64095,
+    "landOccupation": 6.64346,
     "name": "Emmental FR",
     "processId": "a9ab17e5-f011-5f18-af0a-b231e0e68964",
     "rawToCookedRatio": 1.0,
@@ -666,7 +666,7 @@
     "density": 1.0,
     "id": "faa513ae-9c32-4e6c-874e-58c13309339e",
     "inediblePart": 0,
-    "landOccupation": 4.78392,
+    "landOccupation": 4.78585,
     "name": "Mozzarella FR",
     "processId": "8afe86af-857f-5472-98c7-ea884107d8e3",
     "rawToCookedRatio": 1.0,
@@ -681,13 +681,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 0.26909,
-      "hedges": 0.060065,
-      "plotSize": 0.13883
+      "cropDiversity": 0.37233,
+      "hedges": 0.08311,
+      "plotSize": 0.19209
     },
     "id": "1e878bf3-3f3f-4239-a4d8-072c9dec8457",
     "inediblePart": 0.1,
-    "landOccupation": 0.158662,
+    "landOccupation": 0.219535,
     "name": "Betterave rouge Bio",
     "processId": "9a31a1e4-c536-5307-aea5-bf4364c2f15d",
     "rawToCookedRatio": 0.856,
@@ -703,13 +703,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 0.44441,
-      "hedges": 0.091797,
-      "plotSize": 0.13883
+      "cropDiversity": 0.61492,
+      "hedges": 0.12702,
+      "plotSize": 0.19209
     },
     "id": "f36c6c35-1d92-4d7c-8f15-5c4fbe931ed8",
     "inediblePart": 0.1,
-    "landOccupation": 0.158662,
+    "landOccupation": 0.219535,
     "name": "Céleri-rave Bio",
     "processId": "9a31a1e4-c536-5307-aea5-bf4364c2f15d",
     "rawToCookedRatio": 0.856,
@@ -725,13 +725,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 0.44441,
-      "hedges": 0.091797,
-      "plotSize": 0.13883
+      "cropDiversity": 0.44471,
+      "hedges": 0.09186,
+      "plotSize": 0.13892
     },
     "id": "7e64fe4d-001c-42eb-9307-13c8a21d2805",
     "inediblePart": 0.2,
-    "landOccupation": 0.158662,
+    "landOccupation": 0.15877,
     "name": "Navet Bio",
     "processId": "283ea4ac-048d-5555-aa51-ba5bb7b45c0e",
     "rawToCookedRatio": 0.856,
@@ -747,13 +747,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 9.4104,
-      "hedges": 0.7763,
+      "cropDiversity": 9.4105,
+      "hedges": 0.77631,
       "plotSize": 1.1813
     },
     "id": "20aea108-cab8-4223-b8b7-4747599e228c",
     "inediblePart": 0.2,
-    "landOccupation": 2.36264,
+    "landOccupation": 2.36268,
     "name": "Pois chiche Bio",
     "processId": "6c050c28-615b-5863-bcfb-370832bb6e0d",
     "rawToCookedRatio": 2.33,
@@ -775,7 +775,7 @@
     },
     "id": "c466ec83-7735-43b6-a919-c933e6656a8d",
     "inediblePart": 0,
-    "landOccupation": 4.01934,
+    "landOccupation": 4.01946,
     "name": "Soja FR",
     "processId": "0fc050a3-393c-5c39-8171-361c85a80b7c",
     "rawToCookedRatio": 2.33,
@@ -791,13 +791,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 18.21,
+      "cropDiversity": 18.211,
       "hedges": 1.9696,
-      "plotSize": 2.1102
+      "plotSize": 2.1103
     },
     "id": "92d34545-6952-466e-bf6d-c1f1f6069b48",
     "inediblePart": 0,
-    "landOccupation": 5.62729,
+    "landOccupation": 5.62754,
     "name": "Soja Bio",
     "processId": "16d29a2d-4944-50d1-90f5-d3c151853d35",
     "rawToCookedRatio": 2.33,
@@ -819,7 +819,7 @@
     },
     "id": "0cd5d7be-c2a9-4a3d-a3f9-86e351733438",
     "inediblePart": 0,
-    "landOccupation": 2.47554,
+    "landOccupation": 2.47642,
     "name": "Soja (non déforestant) par défaut",
     "processId": "8f7ef559-0d9d-57aa-b698-b5ed621d6f5b",
     "rawToCookedRatio": 2.33,
@@ -841,7 +841,7 @@
     },
     "id": "141f76d7-fe36-4f17-b7da-043ac884a309",
     "inediblePart": 0,
-    "landOccupation": 2.83451,
+    "landOccupation": 2.83548,
     "name": "Soja déforestant par défaut",
     "processId": "9865cef2-f02f-550d-b155-728971443744",
     "rawToCookedRatio": 2.33,
@@ -863,7 +863,7 @@
     },
     "id": "086b58da-1c4c-40a8-9327-37477d04cfba",
     "inediblePart": 0,
-    "landOccupation": 4.02094,
+    "landOccupation": 4.02108,
     "name": "Soja feed par défaut",
     "processId": "0282c8bb-1070-5b25-9614-e61d5148f174",
     "rawToCookedRatio": 2.33,
@@ -879,7 +879,7 @@
     "density": 1.0,
     "id": "d1eb385a-ad1e-44f5-89d1-640c4c91d353",
     "inediblePart": 0,
-    "landOccupation": 9.3484,
+    "landOccupation": 9.35734,
     "name": "Chair à saucisse crue FR",
     "processId": "2225c16a-47f3-52d1-8b52-a8bae1e08e24",
     "rawToCookedRatio": 0.792,
@@ -894,7 +894,7 @@
     "density": 1.0,
     "id": "ee85fceb-7d1f-4871-a0e3-4e88cc816bd5",
     "inediblePart": 0,
-    "landOccupation": 19.3275,
+    "landOccupation": 19.3399,
     "name": "Saucisse de Toulouse (crue) FR",
     "processId": "0a53d3d4-90aa-55d8-9ada-1ad8b5ed5b2b",
     "rawToCookedRatio": 0.792,
@@ -909,7 +909,7 @@
     "density": 1.0,
     "id": "0a86af92-e0c5-4667-9cd2-d63bcc0d9726",
     "inediblePart": 0,
-    "landOccupation": 19.4331,
+    "landOccupation": 19.4461,
     "name": "Saucisse de Toulouse (cuite) FR",
     "processId": "4edc8881-8559-5ee8-8a66-83557d3144e5",
     "rawToCookedRatio": 1.0,
@@ -924,7 +924,7 @@
     "density": 1.0,
     "id": "5799c843-f538-40c8-bd6f-a3b4a4288261",
     "inediblePart": 0,
-    "landOccupation": 1.68537,
+    "landOccupation": 1.68661,
     "name": "Saucisse végétale tofu FR",
     "processId": "98c941c7-3a32-525a-abdd-f0c7a874ced0",
     "rawToCookedRatio": 1.0,
@@ -940,12 +940,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.10913,
-      "plotSize": 0.27282
+      "hedges": 0.11006,
+      "plotSize": 0.27515
     },
     "id": "6523c72b-2c28-474d-9bf8-45e018bbd0be",
     "inediblePart": 0,
-    "landOccupation": 0.436515,
+    "landOccupation": 0.440238,
     "name": "Purée de tomates par défaut",
     "processId": "a3ae0f78-5e38-5835-9c45-82b471c87693",
     "rawToCookedRatio": 1.0,
@@ -962,12 +962,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.2098,
-      "plotSize": 0.52449
+      "hedges": 0.21112,
+      "plotSize": 0.5278
     },
     "id": "55e180a0-9b80-4e0c-9aaf-4613a155d69a",
     "inediblePart": 0,
-    "landOccupation": 0.839183,
+    "landOccupation": 0.844484,
     "name": "Concentré de tomates par défaut",
     "processId": "2b412e3e-3c78-51a2-aafa-e7d2907f3515",
     "rawToCookedRatio": 1.0,
@@ -983,14 +983,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 22.6626,
+      "hedges": 30.7057,
       "livestockDensity": -0.00255,
       "permanentPasture": 24.51,
-      "plotSize": 19.1602
+      "plotSize": 25.8934
     },
     "id": "9db6b0d1-941a-4dda-a347-b7a7fee8fd46",
     "inediblePart": 0.2,
-    "landOccupation": 34.7318,
+    "landOccupation": 34.7358,
     "name": "Viande de boeuf avec os (crue) FR",
     "processId": "d08d4fc1-fea6-5c68-8b59-b62850b16d5e",
     "rawToCookedRatio": 0.792,
@@ -1029,10 +1029,10 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 25.4203,
+      "hedges": 34.474,
       "livestockDensity": -0.00255,
       "permanentPasture": 33.26,
-      "plotSize": 20.7875
+      "plotSize": 28.1915
     },
     "id": "f38271f1-bdba-40cd-a296-2bc741fbf915",
     "inediblePart": 0.2,
@@ -1051,11 +1051,11 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 9.82245,
-      "hedges": 25.9424,
+      "cropDiversity": 9.82287,
+      "hedges": 34.8541,
       "livestockDensity": -0.00267,
       "permanentPasture": 22.67,
-      "plotSize": 23.054
+      "plotSize": 30.625
     },
     "id": "6912db61-530f-4630-956a-b94a6ded0134",
     "inediblePart": 0.2,
@@ -1075,14 +1075,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 28.3285,
+      "hedges": 38.3825,
       "livestockDensity": -0.00255,
       "permanentPasture": 30.63,
-      "plotSize": 23.9515
+      "plotSize": 32.3684
     },
     "id": "22179caa-eb41-49c0-ae04-49eda23da4da",
     "inediblePart": 0,
-    "landOccupation": 43.416,
+    "landOccupation": 43.4211,
     "name": "Viande de boeuf sans os (crue) FR",
     "processId": "48efc88e-dff7-55f0-a1b3-540d17fde967",
     "rawToCookedRatio": 0.792,
@@ -1121,10 +1121,10 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 31.7792,
+      "hedges": 43.0977,
       "livestockDensity": -0.00255,
       "permanentPasture": 41.58,
-      "plotSize": 25.9875
+      "plotSize": 35.2436
     },
     "id": "67db7c6c-a8f8-4285-b1dd-b0b3efe2d668",
     "inediblePart": 0,
@@ -1143,15 +1143,15 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 12.2411,
-      "hedges": 32.419,
+      "cropDiversity": 12.2416,
+      "hedges": 43.5594,
       "livestockDensity": -0.00267,
       "permanentPasture": 28.34,
-      "plotSize": 28.8064
+      "plotSize": 38.2706
     },
     "id": "ff532795-d725-4c6b-82bc-022d38b83bff",
     "inediblePart": 0,
-    "landOccupation": 39.1986,
+    "landOccupation": 44.8319,
     "name": "Viande de boeuf sans os Bio (crue)",
     "processId": "6fe11053-d150-58a6-aba0-315a4a2afdb9",
     "rawToCookedRatio": 0.792,
@@ -1168,12 +1168,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.6772,
-      "plotSize": 2.367
+      "hedges": 1.6817,
+      "plotSize": 2.3734
     },
     "id": "4f3abd56-ed63-4207-afbb-20ac259017e0",
     "inediblePart": 0,
-    "landOccupation": 3.78717,
+    "landOccupation": 3.79749,
     "name": "Semoule de blé dur FR",
     "processId": "ca12b4c3-38d6-5481-9d3b-ccfb64ad602a",
     "rawToCookedRatio": 2.259,
@@ -1190,12 +1190,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.042293,
-      "plotSize": 0.11387
+      "hedges": 0.042433,
+      "plotSize": 0.11424
     },
     "id": "8f075c25-9ebf-430c-b41d-51d165c6e0d8",
     "inediblePart": 0,
-    "landOccupation": 0.455466,
+    "landOccupation": 0.456976,
     "name": "Sucre de betterave FR",
     "processId": "fb996a56-2cf1-5c11-92af-e6384ef9ac39",
     "rawToCookedRatio": 1.0,
@@ -1211,7 +1211,7 @@
     "density": 1.0,
     "id": "6f3939f7-408c-45d5-8653-61f3336bf305",
     "inediblePart": 0,
-    "landOccupation": 11.7952,
+    "landOccupation": 7.26798,
     "name": "Chocolat noir par défaut",
     "processId": "514bd01e-0aaa-5d71-b86a-efeef8fa7784",
     "rawToCookedRatio": 1.0,
@@ -1226,14 +1226,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.66708,
+      "hedges": 1.7164,
       "livestockDensity": -0.022,
       "permanentPasture": 0,
-      "plotSize": 2.78625
+      "plotSize": 2.85266
     },
     "id": "8fb5024c-ceec-4201-b069-ea253c537ad6",
     "inediblePart": 0,
-    "landOccupation": 9.35109,
+    "landOccupation": 9.42511,
     "name": "Blanc de poulet cru (alim. ani. 100%BR) par défaut",
     "processId": "af9d1017-051e-557a-99fd-8012b8ff9f83",
     "rawToCookedRatio": 0.755,
@@ -1249,14 +1249,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 2.54657,
+      "hedges": 2.59614,
       "livestockDensity": -0.01518,
       "permanentPasture": 0,
-      "plotSize": 3.6916
+      "plotSize": 3.75827
     },
     "id": "f94df72e-20fd-4cc5-ab64-ce3921649d58",
     "inediblePart": 0,
-    "landOccupation": 7.29787,
+    "landOccupation": 7.36908,
     "name": "Blanc de poulet cru (alim. ani. 100%FR) FR",
     "processId": "b67d3f40-4457-5f3e-806e-eaaa48c93f41",
     "rawToCookedRatio": 0.755,
@@ -1278,7 +1278,7 @@
     },
     "id": "9b476f8e-08c2-4406-9198-1fb2e007f000",
     "inediblePart": 0,
-    "landOccupation": 1.54198,
+    "landOccupation": 1.54301,
     "name": "Sucre de canne par défaut",
     "processId": "81f2ed5d-41a5-51a8-9590-44478eb6949d",
     "rawToCookedRatio": 1.0,
@@ -1294,13 +1294,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 7.7534,
-      "hedges": 3.6561,
-      "plotSize": 7.3422
+      "cropDiversity": 7.7622,
+      "hedges": 3.6603,
+      "plotSize": 7.3505
     },
     "id": "97f56acd-962e-4a4b-af42-1e468d2017a0",
     "inediblePart": 0,
-    "landOccupation": 8.39111,
+    "landOccupation": 8.40062,
     "name": "Thé (feuilles) UE",
     "processId": "74cf4852-dbbf-5a4c-b82c-735721092903",
     "rawToCookedRatio": 1.0,
@@ -1322,7 +1322,7 @@
     },
     "id": "77be5f12-5124-4828-861c-9ce4ed3fa661",
     "inediblePart": 0,
-    "landOccupation": 11.6771,
+    "landOccupation": 11.6926,
     "name": "Café moulu par défaut",
     "processId": "c9181867-56e9-5cf0-b7a4-b78338ed1079",
     "rawToCookedRatio": 1.0,
@@ -1344,7 +1344,7 @@
     },
     "id": "47b15759-416e-4c86-9127-4c75a55b7b8f",
     "inediblePart": 0,
-    "landOccupation": 16.0709,
+    "landOccupation": 16.0844,
     "name": "Poivre noir par défaut",
     "processId": "e69790ad-d4cc-5345-a330-2d7d03d9b2f6",
     "rawToCookedRatio": 1.0,
@@ -1360,7 +1360,7 @@
     "density": 1.0,
     "id": "b6776a28-ec84-4bf3-988c-07b3c29f6136",
     "inediblePart": 0,
-    "landOccupation": 21.5307,
+    "landOccupation": 21.533,
     "name": "Poudre de lait écrémé FR",
     "processId": "74c3af14-cde9-56d7-8b61-753f29e6729f",
     "rawToCookedRatio": 1.0,
@@ -1376,12 +1376,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.43302,
-      "plotSize": 1.5156
+      "hedges": 0.43403,
+      "plotSize": 1.5191
     },
     "id": "6621c18e-85de-4683-82be-7b236e68bc48",
     "inediblePart": 0,
-    "landOccupation": 1.73209,
+    "landOccupation": 1.73613,
     "name": "Vin rouge FR",
     "processId": "8d85b9dc-d4ea-591d-9c9e-bc1a5cf1419e",
     "rawToCookedRatio": 1.0,
@@ -1397,7 +1397,7 @@
     "density": 1.0,
     "id": "74a86477-3ec2-4f7a-b717-c1794d399e84",
     "inediblePart": 0.2,
-    "landOccupation": 1.85501,
+    "landOccupation": 1.85786,
     "name": "Crevettes fraîches par défaut",
     "processId": "f0c417b7-0ca4-5260-a43d-27f5ee572e43",
     "rawToCookedRatio": 0.819,
@@ -1412,7 +1412,7 @@
     "density": 1.0,
     "id": "dc27661f-3ffa-4f85-b9bb-0028bc7c5fef",
     "inediblePart": 0.2,
-    "landOccupation": 1.55082,
+    "landOccupation": 1.55784,
     "name": "Truite d'élevage FR",
     "processId": "cd495bdf-5d34-52a6-9dcc-0cb80cb60780",
     "rawToCookedRatio": 0.819,
@@ -1427,14 +1427,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.772293,
+      "hedges": 0.799774,
       "livestockDensity": -0.007728,
       "permanentPasture": 0,
-      "plotSize": 0.866613
+      "plotSize": 0.903565
     },
     "id": "cf30d3bc-e99c-418a-b7e3-89a894d410a5",
     "inediblePart": 0.2,
-    "landOccupation": 3.7181,
+    "landOccupation": 3.72068,
     "name": "Oeuf FR",
     "processId": "e0033192-7a17-5024-ad6a-6732470ef8e4",
     "rawToCookedRatio": 0.974,
@@ -1450,14 +1450,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.640204,
+      "hedges": 0.663051,
       "livestockDensity": -0.007728,
       "permanentPasture": 0,
-      "plotSize": 0.718564
+      "plotSize": 0.749285
     },
     "id": "9cbc31e9-80a4-4b87-ac4b-ddc051c47f69",
     "inediblePart": 0.2,
-    "landOccupation": 3.06958,
+    "landOccupation": 3.07156,
     "name": "Oeuf (code 3) FR",
     "processId": "6a0895f2-e8ff-5f7b-b550-d664a3ba4949",
     "rawToCookedRatio": 0.974,
@@ -1473,14 +1473,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.741181,
+      "hedges": 0.767134,
       "livestockDensity": -0.007728,
       "permanentPasture": 0,
-      "plotSize": 0.830595
+      "plotSize": 0.865492
     },
     "id": "b2e75be9-65b8-487d-b5b3-f9c2aa047cf7",
     "inediblePart": 0.2,
-    "landOccupation": 4.26847,
+    "landOccupation": 4.27085,
     "name": "Oeuf (code 1) FR",
     "processId": "0fee082b-600f-57b6-9f67-fc42464c0b0b",
     "rawToCookedRatio": 0.974,
@@ -1495,15 +1495,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 12.9568,
-      "hedges": 2.0134,
+      "cropDiversity": 12.8558,
+      "hedges": 2.00241,
       "livestockDensity": -0.00266,
       "permanentPasture": 0,
-      "plotSize": 2.17891
+      "plotSize": 2.16825
     },
     "id": "cfd4a437-aa49-49ff-818e-353421f2fc09",
     "inediblePart": 0.2,
-    "landOccupation": 6.77893,
+    "landOccupation": 6.78038,
     "name": "Oeuf Bio",
     "processId": "85de2e27-d3b4-5edb-892f-170a07db140d",
     "rawToCookedRatio": 0.974,
@@ -1520,12 +1520,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.29505,
-      "plotSize": 0.9036
+      "hedges": 0.39691,
+      "plotSize": 1.2155
     },
     "id": "e05934df-fd40-4110-a610-0bd686911f2e",
     "inediblePart": 0.1,
-    "landOccupation": 1.03268,
+    "landOccupation": 1.38917,
     "name": "Raisin de cuve Bio",
     "processId": "8f038d28-34b3-558d-a14c-f5a2c778d3cf",
     "rawToCookedRatio": 0.856,
@@ -1541,14 +1541,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 29.8533,
+      "hedges": 41.6413,
       "livestockDensity": 8.4e-5,
       "permanentPasture": 25.0,
-      "plotSize": 25.937
+      "plotSize": 36.1416
     },
     "id": "d79e0fce-8633-4189-a937-7b8010abafed",
     "inediblePart": 0,
-    "landOccupation": 96.5479,
+    "landOccupation": 96.5566,
     "name": "Viande d'agneau (désossée) FR",
     "processId": "85b19f05-dcf6-5bcf-adaf-3054ff7139ab",
     "rawToCookedRatio": 0.792,
@@ -1563,15 +1563,15 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 28.1032,
-      "hedges": 66.9434,
+      "cropDiversity": 28.104,
+      "hedges": 90.8574,
       "livestockDensity": 2.1e-5,
       "permanentPasture": 67.0,
-      "plotSize": 58.9597
+      "plotSize": 79.1024
     },
     "id": "e07f7703-c4f7-479e-a8ac-bb73d3f08c78",
     "inediblePart": 0,
-    "landOccupation": 206.08,
+    "landOccupation": 206.083,
     "name": "Viande d'agneau Bio (désossée)",
     "processId": "60462b4c-c668-50de-bb1f-ee9143a9f6a1",
     "rawToCookedRatio": 0.792,
@@ -1587,13 +1587,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.23994,
-      "hedges": 0.27291,
-      "plotSize": 0.33431
+      "cropDiversity": 0.28599,
+      "hedges": 0.32528,
+      "plotSize": 0.39847
     },
     "id": "57c2fff4-6ad8-4524-a81a-dacdae11deed",
     "inediblePart": 0.1,
-    "landOccupation": 0.382069,
+    "landOccupation": 0.455392,
     "name": "Poire Bio",
     "processId": "2e865489-6f52-53e1-8daa-2b0a4670df77",
     "rawToCookedRatio": 0.856,
@@ -1610,12 +1610,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.030834,
-      "plotSize": 0.077085
+      "hedges": 0.030831,
+      "plotSize": 0.077077
     },
     "id": "4d5198e7-413a-4ae2-8448-535aa3b302ae",
     "inediblePart": 0.1,
-    "landOccupation": 0.123336,
+    "landOccupation": 0.123324,
     "name": "Carotte FR",
     "processId": "37cce1ad-918a-513f-9a9f-2cbad803db16",
     "rawToCookedRatio": 0.856,
@@ -1676,12 +1676,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.024414,
-      "plotSize": 0.061035
+      "hedges": 0.024398,
+      "plotSize": 0.060995
     },
     "id": "a8ba3467-3c82-442a-a73a-98769061b7a9",
     "inediblePart": 0.1,
-    "landOccupation": 0.0976558,
+    "landOccupation": 0.0975918,
     "name": "Courgette FR",
     "processId": "b4aa9f18-bb5d-5945-a91b-4123a672f155",
     "rawToCookedRatio": 0.856,
@@ -1703,7 +1703,7 @@
     },
     "id": "5ef69042-45c5-4b86-b494-1dafcccfc222",
     "inediblePart": 0.1,
-    "landOccupation": 0.228955,
+    "landOccupation": 0.22888,
     "name": "Courgette UE",
     "processId": "05d96115-ab74-5561-8378-f5e63aa2e06a",
     "rawToCookedRatio": 0.856,
@@ -1719,13 +1719,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.22197,
-      "hedges": 0.10467,
-      "plotSize": 0.21019
+      "cropDiversity": 0.22191,
+      "hedges": 0.10464,
+      "plotSize": 0.21014
     },
     "id": "eab762ca-1edc-4fcc-ba6d-c247bbab0ec8",
     "inediblePart": 0.1,
-    "landOccupation": 0.240222,
+    "landOccupation": 0.240158,
     "name": "Poire FR",
     "processId": "ac72c8c0-614c-5569-8806-a604e8aaa9c3",
     "rawToCookedRatio": 0.856,
@@ -1763,13 +1763,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.44053,
-      "hedges": 0.20773,
-      "plotSize": 0.41717
+      "cropDiversity": 0.44049,
+      "hedges": 0.20771,
+      "plotSize": 0.41713
     },
     "id": "a0012089-de27-45ae-89d1-863f71a06e72",
     "inediblePart": 0.2,
-    "landOccupation": 0.476767,
+    "landOccupation": 0.476723,
     "name": "Pêche FR",
     "processId": "b2a5735b-1394-540f-8ce7-94ae67a7c1ad",
     "rawToCookedRatio": 0.856,
@@ -1808,12 +1808,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.10613,
-      "plotSize": 0.26532
+      "hedges": 0.10611,
+      "plotSize": 0.26529
     },
     "id": "dc5c2f84-937c-4059-b7f9-352658cd4c57",
     "inediblePart": 0.4,
-    "landOccupation": 0.424512,
+    "landOccupation": 0.424457,
     "name": "Melon FR",
     "processId": "dbf9fb3d-a447-571b-bcb3-48b92f1df68d",
     "rawToCookedRatio": 0.856,
@@ -1835,7 +1835,7 @@
     },
     "id": "cfabc9a1-1e99-48fc-bfea-9a2fbf6777a6",
     "inediblePart": 0.4,
-    "landOccupation": 0.424512,
+    "landOccupation": 0.424457,
     "name": "Melon UE",
     "processId": "dbf9fb3d-a447-571b-bcb3-48b92f1df68d",
     "rawToCookedRatio": 0.856,
@@ -1852,12 +1852,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.072314,
-      "plotSize": 0.18079
+      "hedges": 0.07231,
+      "plotSize": 0.18078
     },
     "id": "f87309f5-bfbf-49a5-ae57-1a0319a7b7d3",
     "inediblePart": 0.1,
-    "landOccupation": 0.289256,
+    "landOccupation": 0.289242,
     "name": "Pomme de terre industrie FR",
     "processId": "b88dacef-d012-5f6f-9fa1-bcdbdafd9876",
     "rawToCookedRatio": 0.856,
@@ -1874,12 +1874,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.072316,
-      "plotSize": 0.18079
+      "hedges": 0.072312,
+      "plotSize": 0.18078
     },
     "id": "1bcf7aa8-a26c-4340-b98a-c41d015a99b7",
     "inediblePart": 0.1,
-    "landOccupation": 0.289262,
+    "landOccupation": 0.289247,
     "name": "Pomme de terre de table FR",
     "processId": "d0f0c49b-5815-5840-80e1-5fa626e5379f",
     "rawToCookedRatio": 0.856,
@@ -1918,12 +1918,12 @@
     "density": 0.6195,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.065,
-      "plotSize": 0.1625
+      "hedges": 0.066103,
+      "plotSize": 0.16526
     },
     "id": "97cde31b-e46e-472d-836d-9b217c3845df",
     "inediblePart": 0.1,
-    "landOccupation": 0.26,
+    "landOccupation": 0.26441,
     "name": "Oignon FR",
     "processId": "bc2b7e2a-870e-5e15-ae1b-13e517ddc92e",
     "rawToCookedRatio": 0.856,
@@ -1984,12 +1984,12 @@
     "density": 0.398,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.024414,
-      "plotSize": 0.061035
+      "hedges": 0.024398,
+      "plotSize": 0.060995
     },
     "id": "ed8ac786-b948-475f-ba0a-0b51b9343d1b",
     "inediblePart": 0.1,
-    "landOccupation": 0.0976558,
+    "landOccupation": 0.0975918,
     "name": "Aubergine FR",
     "processId": "b4aa9f18-bb5d-5945-a91b-4123a672f155",
     "rawToCookedRatio": 0.856,
@@ -2011,7 +2011,7 @@
     },
     "id": "da1bb644-0d37-467f-8c7a-53300b58b0cf",
     "inediblePart": 0.1,
-    "landOccupation": 0.0976558,
+    "landOccupation": 0.0975918,
     "name": "Aubergine UE",
     "processId": "b4aa9f18-bb5d-5945-a91b-4123a672f155",
     "rawToCookedRatio": 0.856,
@@ -2029,11 +2029,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.33389,
-      "plotSize": 0.83473
+      "plotSize": 0.83472
     },
     "id": "37101a07-9e1f-478d-803a-dad5693dcd8c",
     "inediblePart": 0.1,
-    "landOccupation": 1.33556,
+    "landOccupation": 1.33554,
     "name": "Haricot vert FR",
     "processId": "ccfeb5f8-0b6b-5c60-b208-e2f60a37faf3",
     "rawToCookedRatio": 0.856,
@@ -2055,7 +2055,7 @@
     },
     "id": "3934ba18-fd22-47f4-ad2e-31805ad8a5f7",
     "inediblePart": 0.1,
-    "landOccupation": 1.33556,
+    "landOccupation": 1.33554,
     "name": "Haricot vert UE",
     "processId": "ccfeb5f8-0b6b-5c60-b208-e2f60a37faf3",
     "rawToCookedRatio": 0.856,
@@ -2077,7 +2077,7 @@
     },
     "id": "a38c77d5-be6c-49e5-beb0-d8d88d556392",
     "inediblePart": 0.1,
-    "landOccupation": 1.33556,
+    "landOccupation": 1.33554,
     "name": "Haricot vert par défaut",
     "processId": "ccfeb5f8-0b6b-5c60-b208-e2f60a37faf3",
     "rawToCookedRatio": 0.856,
@@ -2094,12 +2094,12 @@
     "density": 0.118,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.027223,
-      "plotSize": 0.068056
+      "hedges": 0.027216,
+      "plotSize": 0.06804
     },
     "id": "6348bb16-2d8c-4b82-8dbc-8b7dc587c09b",
     "inediblePart": 0.4,
-    "landOccupation": 0.10889,
+    "landOccupation": 0.108865,
     "name": "Laitue FR",
     "processId": "0fa6b3c3-4c23-5a4b-9b75-fcbbf2d7cff2",
     "rawToCookedRatio": 0.856,
@@ -2160,12 +2160,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.345,
-      "plotSize": 0.8625
+      "hedges": 0.34531,
+      "plotSize": 0.86328
     },
     "id": "05c2db96-2658-4842-8c30-53e878b08931",
     "inediblePart": 0.2,
-    "landOccupation": 1.38,
+    "landOccupation": 1.38126,
     "name": "Petit pois FR",
     "processId": "88c9a2b8-c7f3-5b1c-a64d-0e681fd7db15",
     "rawToCookedRatio": 2.33,
@@ -2187,7 +2187,7 @@
     },
     "id": "3f4037f4-8c7a-45f7-b376-ec48357db98d",
     "inediblePart": 0.2,
-    "landOccupation": 1.38,
+    "landOccupation": 1.38126,
     "name": "Petit pois UE",
     "processId": "88c9a2b8-c7f3-5b1c-a64d-0e681fd7db15",
     "rawToCookedRatio": 2.33,
@@ -2203,13 +2203,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 12.991,
-      "hedges": 6.1261,
-      "plotSize": 12.303
+      "cropDiversity": 12.99,
+      "hedges": 6.1254,
+      "plotSize": 12.301
     },
     "id": "8ea6e0d1-a163-4059-8a6b-bd443f0168db",
     "inediblePart": 0.2,
-    "landOccupation": 14.06,
+    "landOccupation": 14.0582,
     "name": "Cerise FR",
     "processId": "852e4814-4226-570e-ba8c-f5826226d4c1",
     "rawToCookedRatio": 0.856,
@@ -2247,13 +2247,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 12.991,
-      "hedges": 6.1261,
-      "plotSize": 12.303
+      "cropDiversity": 12.99,
+      "hedges": 6.1254,
+      "plotSize": 12.301
     },
     "id": "7829330e-e744-4495-bbe3-c372323ba2a5",
     "inediblePart": 0.2,
-    "landOccupation": 14.06,
+    "landOccupation": 14.0582,
     "name": "Prune FR",
     "processId": "852e4814-4226-570e-ba8c-f5826226d4c1",
     "rawToCookedRatio": 0.856,
@@ -2270,12 +2270,12 @@
     "density": 0.362,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.024414,
-      "plotSize": 0.061035
+      "hedges": 0.024398,
+      "plotSize": 0.060995
     },
     "id": "6689fb67-0118-4dff-b74e-0c8de81ef65b",
     "inediblePart": 0.2,
-    "landOccupation": 0.0976558,
+    "landOccupation": 0.0975918,
     "name": "Courge FR",
     "processId": "b4aa9f18-bb5d-5945-a91b-4123a672f155",
     "rawToCookedRatio": 0.856,
@@ -2297,7 +2297,7 @@
     },
     "id": "14335872-a8d9-4496-b771-cb80c21ad604",
     "inediblePart": 0.2,
-    "landOccupation": 0.228955,
+    "landOccupation": 0.22888,
     "name": "Courge UE",
     "processId": "05d96115-ab74-5561-8378-f5e63aa2e06a",
     "rawToCookedRatio": 0.856,
@@ -2313,13 +2313,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 0.37953,
-      "hedges": 0.078395,
-      "plotSize": 0.11856
+      "cropDiversity": 0.37941,
+      "hedges": 0.07837,
+      "plotSize": 0.11852
     },
     "id": "bbee841c-6675-49ae-92da-2064877f6d14",
     "inediblePart": 0.2,
-    "landOccupation": 0.135498,
+    "landOccupation": 0.135454,
     "name": "Courge Bio",
     "processId": "30b69d8c-c7e7-53b5-8317-9a00f3330526",
     "rawToCookedRatio": 0.856,
@@ -2336,12 +2336,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.01,
-      "plotSize": 0.025
+      "hedges": 0.0097929,
+      "plotSize": 0.024482
     },
     "id": "a96c560e-7959-4698-b533-23f922bb62b9",
     "inediblePart": 0.03,
-    "landOccupation": 0.04,
+    "landOccupation": 0.0391715,
     "name": "Tomate sous serre chauffée par défaut",
     "processId": "6645209b-64fa-5f1e-be93-4615814df356",
     "rawToCookedRatio": 0.856,
@@ -2358,12 +2358,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.015,
-      "plotSize": 0.0375
+      "hedges": 0.015017,
+      "plotSize": 0.037543
     },
     "id": "16caaefa-40f5-4d29-a3e6-26349846f2c9",
     "inediblePart": 0.03,
-    "landOccupation": 0.06,
+    "landOccupation": 0.0600685,
     "name": "Tomate sous serre non chauffée FR",
     "processId": "5e7d0a76-4499-5ea6-987c-799443d641cd",
     "rawToCookedRatio": 0.856,
@@ -2451,7 +2451,7 @@
     },
     "id": "dfc9b995-2862-4abf-9af9-f3e8e403f325",
     "inediblePart": 0.5,
-    "landOccupation": 8.1,
+    "landOccupation": 8.0993,
     "name": "Noisette avec coque par défaut",
     "processId": "008322e1-3451-52da-897c-271b8d51d46d",
     "rawToCookedRatio": 1.0,
@@ -2473,7 +2473,7 @@
     },
     "id": "dd6c5ca4-9d8a-4b4f-9d5e-fada405f7c39",
     "inediblePart": 0.5,
-    "landOccupation": 7.05424,
+    "landOccupation": 7.05296,
     "name": "Noisette avec coque UE",
     "processId": "9cac6a0e-0b07-5046-b391-af1161c04be0",
     "rawToCookedRatio": 1.0,
@@ -2495,7 +2495,7 @@
     },
     "id": "3af43703-cba3-4992-837c-a1392b5c6221",
     "inediblePart": 0.5,
-    "landOccupation": 14.1135,
+    "landOccupation": 14.1109,
     "name": "Noisette décortiquée UE",
     "processId": "89ab67b7-b928-50f2-af53-cf5c0517e67f",
     "rawToCookedRatio": 1.0,
@@ -2534,12 +2534,12 @@
     "density": 0.362,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.11128,
-      "plotSize": 0.2782
+      "hedges": 0.11127,
+      "plotSize": 0.27818
     },
     "id": "51eea2d1-abec-4459-aae0-15f8348d0994",
     "inediblePart": 0.6,
-    "landOccupation": 0.445121,
+    "landOccupation": 0.445095,
     "name": "Artichaut FR",
     "processId": "66065729-d03d-5b6e-9886-61de459fa512",
     "rawToCookedRatio": 0.856,
@@ -2555,13 +2555,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 2.1628,
-      "hedges": 0.44674,
-      "plotSize": 0.67562
+      "cropDiversity": 2.1773,
+      "hedges": 0.44974,
+      "plotSize": 0.68016
     },
     "id": "d7630e82-2b60-46cc-b50d-451a32e0887e",
     "inediblePart": 0.6,
-    "landOccupation": 0.77214,
+    "landOccupation": 0.777328,
     "name": "Artichaut Bio",
     "processId": "fd3f416b-2d5a-57b0-ab91-ad84990345a9",
     "rawToCookedRatio": 0.856,
@@ -2577,13 +2577,13 @@
     "defaultOrigin": "France",
     "density": 0.2355,
     "ecosystemicServices": {
-      "cropDiversity": 1.8869,
-      "hedges": 0.38976,
-      "plotSize": 0.58945
+      "cropDiversity": 1.8868,
+      "hedges": 0.38973,
+      "plotSize": 0.58941
     },
     "id": "0f747732-1b0d-40ba-89a2-715fecd5454f",
     "inediblePart": 0.2,
-    "landOccupation": 0.673652,
+    "landOccupation": 0.673607,
     "name": "Chou-fleur Bio",
     "processId": "9e9c4463-cdb8-5898-b2cb-9eae73341580",
     "rawToCookedRatio": 0.856,
@@ -2601,11 +2601,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.11548,
-      "plotSize": 0.28871
+      "plotSize": 0.28869
     },
     "id": "a28383f4-4345-44fb-ada3-985d66492f97",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou-fleur FR",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -2622,12 +2622,12 @@
     "density": 0.6195,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.043229,
-      "plotSize": 0.10807
+      "hedges": 0.04321,
+      "plotSize": 0.10803
     },
     "id": "1d31a371-690d-41dd-9615-2e58bac40e62",
     "inediblePart": 0.2,
-    "landOccupation": 0.172918,
+    "landOccupation": 0.172841,
     "name": "Poireau FR",
     "processId": "fac7ee85-b1e1-5170-a770-a304716b6d3d",
     "rawToCookedRatio": 0.856,
@@ -2644,12 +2644,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.011453,
-      "plotSize": 0.030834
+      "hedges": 0.011451,
+      "plotSize": 0.030831
     },
     "id": "e3dd5653-be1e-42b1-b11f-e46600d31c3e",
     "inediblePart": 0.1,
-    "landOccupation": 0.123336,
+    "landOccupation": 0.123324,
     "name": "Betterave rouge FR",
     "processId": "37cce1ad-918a-513f-9a9f-2cbad803db16",
     "rawToCookedRatio": 0.856,
@@ -2666,12 +2666,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.030834,
-      "plotSize": 0.077085
+      "hedges": 0.030831,
+      "plotSize": 0.077077
     },
     "id": "9a64a770-f1b0-4980-a5e3-9ea34f930b0d",
     "inediblePart": 0.2,
-    "landOccupation": 0.123336,
+    "landOccupation": 0.123324,
     "name": "Navet FR",
     "processId": "37cce1ad-918a-513f-9a9f-2cbad803db16",
     "rawToCookedRatio": 0.856,
@@ -2733,11 +2733,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.11548,
-      "plotSize": 0.28871
+      "plotSize": 0.28869
     },
     "id": "65f1221e-cf4c-413b-b023-8cec646e8ee4",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou chinois FR",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -2753,13 +2753,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 2.1628,
-      "hedges": 0.44674,
-      "plotSize": 0.67562
+      "cropDiversity": 2.1823,
+      "hedges": 0.45078,
+      "plotSize": 0.68174
     },
     "id": "701f6e68-9eb9-4ee2-8b40-a3553811bda4",
     "inediblePart": 0.2,
-    "landOccupation": 0.77214,
+    "landOccupation": 0.779132,
     "name": "Chou chinois Bio",
     "processId": "eba51895-1c4d-5a81-b404-eafdade4903d",
     "rawToCookedRatio": 0.856,
@@ -2799,11 +2799,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.11548,
-      "plotSize": 0.28871
+      "plotSize": 0.28869
     },
     "id": "ddba1d97-7db9-4ab6-8bc7-43891f69b02c",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou vert FR",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -2819,13 +2819,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 1.8869,
-      "hedges": 0.38976,
-      "plotSize": 0.58945
+      "cropDiversity": 1.8868,
+      "hedges": 0.38973,
+      "plotSize": 0.58941
     },
     "id": "aef5e0f4-7f91-4b75-b1e8-04594c64a538",
     "inediblePart": 0.2,
-    "landOccupation": 0.673652,
+    "landOccupation": 0.673607,
     "name": "Chou vert Bio",
     "processId": "9e9c4463-cdb8-5898-b2cb-9eae73341580",
     "rawToCookedRatio": 0.856,
@@ -2847,7 +2847,7 @@
     },
     "id": "28f7c945-14d0-4d83-b04d-ea09f48a05b2",
     "inediblePart": 0.2,
-    "landOccupation": 0.11,
+    "landOccupation": 0.109163,
     "name": "Chou rouge par défaut",
     "processId": "da587723-8c38-5f26-8d99-680471a579da",
     "rawToCookedRatio": 0.856,
@@ -2864,12 +2864,12 @@
     "density": 0.6195,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.065,
-      "plotSize": 0.1625
+      "hedges": 0.066103,
+      "plotSize": 0.16526
     },
     "id": "f83eb463-aa6e-4b64-96ab-6f478152410d",
     "inediblePart": 0.1,
-    "landOccupation": 0.26,
+    "landOccupation": 0.26441,
     "name": "Echalote FR",
     "processId": "bc2b7e2a-870e-5e15-ae1b-13e517ddc92e",
     "rawToCookedRatio": 0.856,
@@ -2891,7 +2891,7 @@
     },
     "id": "af47d8b1-2c50-4f3f-8d10-1941133bd100",
     "inediblePart": 0.2,
-    "landOccupation": 0.34941,
+    "landOccupation": 0.348941,
     "name": "Orange UE",
     "processId": "f95aed4c-b3fa-513b-9b5a-9eacba761b4a",
     "rawToCookedRatio": 0.856,
@@ -2953,7 +2953,7 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.83047,
-      "plotSize": 0.90833
+      "plotSize": 0.90832
     },
     "id": "6a4df71d-3a0e-4477-8086-010f6a72ffec",
     "inediblePart": 0,
@@ -3062,12 +3062,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 5.8431,
-      "plotSize": 10.526
+      "hedges": 5.845,
+      "plotSize": 10.53
     },
     "id": "f1b219e6-7a77-429b-b372-461e3ad0d3bd",
     "inediblePart": 0,
-    "landOccupation": 12.03,
+    "landOccupation": 12.0339,
     "name": "Huile d'olive UE",
     "processId": "d0d1057d-ccab-5f2a-b5f9-9e28d56a77a1",
     "rawToCookedRatio": 1.0,
@@ -3106,12 +3106,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.57793,
-      "plotSize": 1.395
+      "hedges": 0.57879,
+      "plotSize": 1.3971
     },
     "id": "89035410-466b-4c9d-8726-98f0928b664b",
     "inediblePart": 0.2,
-    "landOccupation": 2.79,
+    "landOccupation": 2.79414,
     "name": "Pois chiche FR",
     "processId": "c426ce20-85f9-5ae4-91da-d1e015cd445d",
     "rawToCookedRatio": 2.33,
@@ -3127,13 +3127,13 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 1.9223,
-      "hedges": 1.3629,
-      "plotSize": 1.7887
+      "cropDiversity": 1.9217,
+      "hedges": 1.3625,
+      "plotSize": 1.7882
     },
     "id": "f105f36b-f467-4aea-8da7-8bc2e113db20",
     "inediblePart": 0.5,
-    "landOccupation": 4.77,
+    "landOccupation": 4.76861,
     "name": "Tournesol FR",
     "processId": "a0b4cdb4-e9a7-5a10-925c-3b435d58ae59",
     "rawToCookedRatio": 1.0,
@@ -3155,7 +3155,7 @@
     },
     "id": "23cd53c5-4b66-4b7c-892f-fe74054f66e5",
     "inediblePart": 0.5,
-    "landOccupation": 2.124,
+    "landOccupation": 2.12399,
     "name": "Tournesol UE",
     "processId": "6d737375-f7f8-5d68-aed5-df00b19e90f7",
     "rawToCookedRatio": 1.0,
@@ -3177,7 +3177,7 @@
     },
     "id": "a2d31857-322c-40a7-a0a4-563e74a685d2",
     "inediblePart": 0.5,
-    "landOccupation": 3.49449,
+    "landOccupation": 3.49448,
     "name": "Tournesol par défaut",
     "processId": "fb685215-e9fb-5673-88e8-99a44bea7ae8",
     "rawToCookedRatio": 1.0,
@@ -3193,13 +3193,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.88899,
-      "hedges": 0.4192,
-      "plotSize": 0.84184
+      "cropDiversity": 0.88897,
+      "hedges": 0.41919,
+      "plotSize": 0.84183
     },
     "id": "f3ed8d7b-21be-4d21-aae0-fee3ae914224",
     "inediblePart": 0.1,
-    "landOccupation": 0.962105,
+    "landOccupation": 0.962086,
     "name": "Kiwi FR",
     "processId": "ae81e897-0672-5926-b967-6a95ed4a6e74",
     "rawToCookedRatio": 0.856,
@@ -3265,7 +3265,7 @@
     },
     "id": "db0e5f44-34b4-4160-b003-77c828d75e60",
     "inediblePart": 0.2,
-    "landOccupation": 0.41,
+    "landOccupation": 0.410125,
     "name": "Mangue par défaut",
     "processId": "7593f9cb-9e30-57de-8d56-3f34fe6c70ea",
     "rawToCookedRatio": 0.856,
@@ -3287,7 +3287,7 @@
     },
     "id": "f46de7f5-4bf0-45f4-b75b-3e00164dd9ca",
     "inediblePart": 0.03,
-    "landOccupation": 0.05,
+    "landOccupation": 0.0462044,
     "name": "Epinard par défaut",
     "processId": "f4f0f1ad-fb1e-5a77-b7c7-295bab0aa450",
     "rawToCookedRatio": 0.856,
@@ -3305,7 +3305,7 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.039703,
-      "plotSize": 0.099257
+      "plotSize": 0.099258
     },
     "id": "63717c79-e734-4af3-bc3c-d75070f1822d",
     "inediblePart": 0.2,
@@ -3375,7 +3375,7 @@
     },
     "id": "b193fd9e-99ab-4d1b-8e81-3b38bab2eacf",
     "inediblePart": 0.03,
-    "landOccupation": 3.45,
+    "landOccupation": 3.45114,
     "name": "Myrtille par défaut",
     "processId": "e2685c22-5b8b-57b9-b112-590de9ce9b7f",
     "rawToCookedRatio": 0.856,
@@ -3397,7 +3397,7 @@
     },
     "id": "50939126-d4a5-4b94-b110-63e8b9e66173",
     "inediblePart": 0.03,
-    "landOccupation": 2.03,
+    "landOccupation": 2.02866,
     "name": "Framboise UE",
     "processId": "b5cc81b8-a6b6-5ad6-8841-b72e825ec7ed",
     "rawToCookedRatio": 0.856,
@@ -3419,7 +3419,7 @@
     },
     "id": "ce20da3d-0ce4-49e9-8942-6d99ff0221b1",
     "inediblePart": 0.03,
-    "landOccupation": 1.95167,
+    "landOccupation": 0.0288161,
     "name": "Fraise UE",
     "processId": "0bbd4c8b-513d-5abe-8bfc-ae981646eb1b",
     "rawToCookedRatio": 0.856,
@@ -3441,7 +3441,7 @@
     },
     "id": "e5bf7d33-6afe-46d6-ac06-f69c5769b10e",
     "inediblePart": 0.03,
-    "landOccupation": 1.26885,
+    "landOccupation": 0.0280587,
     "name": "Fraise par défaut",
     "processId": "4ef5c851-6dec-5e0f-b758-a694732f7c1a",
     "rawToCookedRatio": 0.856,
@@ -3457,13 +3457,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.32134,
-      "hedges": 0.15153,
-      "plotSize": 0.3043
+      "cropDiversity": 0.32133,
+      "hedges": 0.15152,
+      "plotSize": 0.30429
     },
     "id": "127b7cfe-0686-4455-8f8d-3c8bc034cbf9",
     "inediblePart": 0.3,
-    "landOccupation": 0.347772,
+    "landOccupation": 0.347759,
     "name": "Banane par défaut",
     "processId": "03c717e8-da0d-51dd-a9d0-56379b532557",
     "rawToCookedRatio": 0.856,
@@ -3485,7 +3485,7 @@
     },
     "id": "f79d155e-3f9e-4882-8dd0-b03f28c1ff76",
     "inediblePart": 0.3,
-    "landOccupation": 0.275997,
+    "landOccupation": 0.275967,
     "name": "Banane par défaut",
     "processId": "90f4690b-2ffd-580f-8848-ed3f1ce1e0a1",
     "rawToCookedRatio": 0.856,
@@ -3502,12 +3502,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.015,
-      "plotSize": 0.0375
+      "hedges": 0.015017,
+      "plotSize": 0.037543
     },
     "id": "d47b842a-f591-4ce9-9f1d-2aebcaaa3c37",
     "inediblePart": 0.1,
-    "landOccupation": 0.06,
+    "landOccupation": 0.0600685,
     "name": "Concombre de saison FR",
     "processId": "5e7d0a76-4499-5ea6-987c-799443d641cd",
     "rawToCookedRatio": 0.856,
@@ -3568,12 +3568,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.15952,
-      "plotSize": 0.3988
+      "hedges": 0.15949,
+      "plotSize": 0.39873
     },
     "id": "800c5ae3-677d-4e12-9dd8-1c11cd69a210",
     "inediblePart": 0.03,
-    "landOccupation": 0.638086,
+    "landOccupation": 0.63797,
     "name": "Fraise de saison FR ",
     "processId": "371408e3-0071-5441-b52b-281e7c769ac9",
     "rawToCookedRatio": 0.856,
@@ -3590,12 +3590,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.27054,
-      "plotSize": 0.67634
+      "hedges": 0.27052,
+      "plotSize": 0.6763
     },
     "id": "3c20126c-e2ab-403b-8bbc-0fc0d2fd3a1b",
     "inediblePart": 0.03,
-    "landOccupation": 1.08214,
+    "landOccupation": 1.08208,
     "name": "Fraise hors saison FR",
     "processId": "db14ecbb-3be0-5737-ab81-61ce637a7d5e",
     "rawToCookedRatio": 0.856,
@@ -3656,12 +3656,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.030834,
-      "plotSize": 0.077085
+      "hedges": 0.030831,
+      "plotSize": 0.077077
     },
     "id": "88c0d4ba-93d6-4a41-94e6-ccec49cce325",
     "inediblePart": 0.03,
-    "landOccupation": 0.123336,
+    "landOccupation": 0.123324,
     "name": "Céleri-rave FR",
     "processId": "37cce1ad-918a-513f-9a9f-2cbad803db16",
     "rawToCookedRatio": 0.856,
@@ -3722,12 +3722,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.959,
-      "plotSize": 5.7138
+      "hedges": 1.9584,
+      "plotSize": 5.712
     },
     "id": "6aacd47b-541c-4aab-85fb-bcd2c924effb",
     "inediblePart": 0.5,
-    "landOccupation": 6.53,
+    "landOccupation": 6.52804,
     "name": "Noix avec coque FR",
     "processId": "c950c222-2532-50ad-9147-e65600b921ba",
     "rawToCookedRatio": 1.0,
@@ -3744,12 +3744,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.8487,
-      "plotSize": 5.3919
+      "hedges": 1.8486,
+      "plotSize": 5.3917
     },
     "id": "63bc644e-fc29-45a5-a505-6a28c8f266c5",
     "inediblePart": 0.5,
-    "landOccupation": 6.16222,
+    "landOccupation": 6.16195,
     "name": "Noix décortiquées FR",
     "processId": "ebe13be3-f0bf-57a7-9def-e785d2b12792",
     "rawToCookedRatio": 1.0,
@@ -3766,12 +3766,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.8487,
-      "plotSize": 5.3919
+      "hedges": 1.8486,
+      "plotSize": 5.3917
     },
     "id": "deb218ab-9c48-41ea-a9c7-6acc185cd83c",
     "inediblePart": 0.5,
-    "landOccupation": 6.16222,
+    "landOccupation": 6.16195,
     "name": "Châtaigne décortiquée FR",
     "processId": "ebe13be3-f0bf-57a7-9def-e785d2b12792",
     "rawToCookedRatio": 1.0,
@@ -3788,12 +3788,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.839,
-      "plotSize": 5.3637
+      "hedges": 1.8404,
+      "plotSize": 5.3679
     },
     "id": "ae6a572a-d814-495e-b6a9-5b0acff707d9",
     "inediblePart": 0.5,
-    "landOccupation": 6.13,
+    "landOccupation": 6.13472,
     "name": "Châtaigne avec coque FR",
     "processId": "fc11f492-148e-50b1-a041-248c6360fc47",
     "rawToCookedRatio": 1.0,
@@ -3837,7 +3837,7 @@
     },
     "id": "5d22559d-c16d-4545-94b9-be2ff51e2879",
     "inediblePart": 0.1,
-    "landOccupation": 0.51,
+    "landOccupation": 0.514552,
     "name": "Champignon frais UE",
     "processId": "973dcd67-31ce-5a1c-8db6-152cbc241232",
     "rawToCookedRatio": 0.856,
@@ -3855,11 +3855,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.11548,
-      "plotSize": 0.28871
+      "plotSize": 0.28869
     },
     "id": "f8e12f3a-6308-425c-bede-f8f9dbe405ee",
     "inediblePart": 0.1,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou de Bruxelles FR",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -3875,13 +3875,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 1.8869,
-      "hedges": 0.38976,
-      "plotSize": 0.58945
+      "cropDiversity": 1.8868,
+      "hedges": 0.38973,
+      "plotSize": 0.58941
     },
     "id": "65296024-b028-46c2-be67-84068893cfe3",
     "inediblePart": 0.1,
-    "landOccupation": 0.673652,
+    "landOccupation": 0.673607,
     "name": "Chou de Bruxelles Bio",
     "processId": "9e9c4463-cdb8-5898-b2cb-9eae73341580",
     "rawToCookedRatio": 0.856,
@@ -3898,12 +3898,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.2396,
-      "plotSize": 2.9922
+      "hedges": 1.2397,
+      "plotSize": 2.9924
     },
     "id": "e3833045-a0a4-48c7-ab73-5a01834b0219",
     "inediblePart": 0,
-    "landOccupation": 5.98439,
+    "landOccupation": 5.98476,
     "name": "Lentilles FR",
     "processId": "e45f6ccb-035e-569c-80c5-f8a26993c5b3",
     "rawToCookedRatio": 2.33,
@@ -3921,11 +3921,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.11548,
-      "plotSize": 0.28871
+      "plotSize": 0.28869
     },
     "id": "40969824-958c-47b7-8e9e-6b3e80bb1176",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou frisé FR",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -3941,13 +3941,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 1.8869,
-      "hedges": 0.38976,
-      "plotSize": 0.58945
+      "cropDiversity": 1.8868,
+      "hedges": 0.38973,
+      "plotSize": 0.58941
     },
     "id": "577ca86a-b599-4757-9b98-712529a29738",
     "inediblePart": 0.2,
-    "landOccupation": 0.673652,
+    "landOccupation": 0.673607,
     "name": "Chou frisé Bio",
     "processId": "9e9c4463-cdb8-5898-b2cb-9eae73341580",
     "rawToCookedRatio": 0.856,
@@ -3964,12 +3964,12 @@
     "density": 0.362,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.057239,
-      "plotSize": 0.1431
+      "hedges": 0.05722,
+      "plotSize": 0.14305
     },
     "id": "ae0e7729-1bff-4c3b-8dc8-62bdb827345d",
     "inediblePart": 0.2,
-    "landOccupation": 0.228955,
+    "landOccupation": 0.22888,
     "name": "Citrouille FR",
     "processId": "05d96115-ab74-5561-8378-f5e63aa2e06a",
     "rawToCookedRatio": 0.856,
@@ -3991,7 +3991,7 @@
     },
     "id": "299941e9-577c-4618-968c-6901ffa99a8d",
     "inediblePart": 0.2,
-    "landOccupation": 0.531675,
+    "landOccupation": 0.531658,
     "name": "Clémentine par défaut",
     "processId": "c6598f48-29cb-5b7c-9add-d58080fbd04c",
     "rawToCookedRatio": 0.856,
@@ -4008,12 +4008,12 @@
     "density": 0.118,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.027223,
-      "plotSize": 0.068056
+      "hedges": 0.027216,
+      "plotSize": 0.06804
     },
     "id": "b26efb2f-8811-4fbb-9d01-3d7f0d8135ef",
     "inediblePart": 0.2,
-    "landOccupation": 0.10889,
+    "landOccupation": 0.108865,
     "name": "Endive FR",
     "processId": "0fa6b3c3-4c23-5a4b-9b75-fcbbf2d7cff2",
     "rawToCookedRatio": 0.856,
@@ -4052,12 +4052,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.27049,
-      "plotSize": 0.94671
+      "hedges": 0.24237,
+      "plotSize": 0.8483
     },
     "id": "88d41160-fad0-4f85-b911-704dcfb387e4",
     "inediblePart": 0.1,
-    "landOccupation": 1.08196,
+    "landOccupation": 0.96949,
     "name": "Raisin de cuve FR",
     "processId": "36d90e73-5553-5eae-8652-3522dec59c7a",
     "rawToCookedRatio": 0.856,
@@ -4074,12 +4074,12 @@
     "density": 0.118,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.027223,
-      "plotSize": 0.068056
+      "hedges": 0.027216,
+      "plotSize": 0.06804
     },
     "id": "4f53cbe2-feac-42ea-90cf-62856732103b",
     "inediblePart": 0.4,
-    "landOccupation": 0.10889,
+    "landOccupation": 0.108865,
     "name": "Mâche FR",
     "processId": "0fa6b3c3-4c23-5a4b-9b75-fcbbf2d7cff2",
     "rawToCookedRatio": 0.856,
@@ -4118,12 +4118,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.46289,
-      "plotSize": 0.4765
+      "hedges": 0.46302,
+      "plotSize": 0.47664
     },
     "id": "40fa68b6-381e-4dd6-ba70-8b43cfdee64e",
     "inediblePart": 0.5,
-    "landOccupation": 0.953,
+    "landOccupation": 0.953277,
     "name": "Maïs doux FR",
     "processId": "6f6b1e9b-db7f-568a-bb80-a237c615e706",
     "rawToCookedRatio": 2.259,
@@ -4139,13 +4139,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 1.5285,
-      "hedges": 0.81568,
-      "plotSize": 0.73202
+      "cropDiversity": 1.5286,
+      "hedges": 0.81578,
+      "plotSize": 0.73211
     },
     "id": "741c0970-2823-430a-b4e4-e61ce08ea95a",
     "inediblePart": 0.5,
-    "landOccupation": 1.46404,
+    "landOccupation": 1.46421,
     "name": "Maïs doux Bio",
     "processId": "4554e0a7-4ea3-59b2-8f90-1aac62d21829",
     "rawToCookedRatio": 2.259,
@@ -4167,7 +4167,7 @@
     },
     "id": "be9a2aa4-4c8b-4801-abcf-01ba1581f053",
     "inediblePart": 0.5,
-    "landOccupation": 2.25698,
+    "landOccupation": 2.25759,
     "name": "Maïs doux par défaut",
     "processId": "fe182ad6-7885-5f31-9afb-11b26d1af210",
     "rawToCookedRatio": 2.259,
@@ -4211,7 +4211,7 @@
     },
     "id": "ec58c11c-c5fd-4884-8d66-3d434aa1da1d",
     "inediblePart": 0.2,
-    "landOccupation": 2.8,
+    "landOccupation": 2.80125,
     "name": "Fève UE",
     "processId": "d21e3ed0-01e3-5f17-955f-10171826a34a",
     "rawToCookedRatio": 2.33,
@@ -4228,12 +4228,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.66,
-      "plotSize": 1.05
+      "hedges": 0.66029,
+      "plotSize": 1.0505
     },
     "id": "d1d5713d-021f-4438-95c8-0496da3f0f5f",
     "inediblePart": 0.2,
-    "landOccupation": 2.8,
+    "landOccupation": 2.80125,
     "name": "Fève FR",
     "processId": "d21e3ed0-01e3-5f17-955f-10171826a34a",
     "rawToCookedRatio": 2.33,
@@ -4272,12 +4272,12 @@
     "density": 0.118,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.0046429,
-      "plotSize": 0.0125
+      "hedges": 0.0042904,
+      "plotSize": 0.011551
     },
     "id": "2920acc6-000a-4f43-9525-7d619d19f62e",
     "inediblePart": 0.03,
-    "landOccupation": 0.05,
+    "landOccupation": 0.0462044,
     "name": "Blette FR",
     "processId": "f4f0f1ad-fb1e-5a77-b7c7-295bab0aa450",
     "rawToCookedRatio": 0.856,
@@ -4299,7 +4299,7 @@
     },
     "id": "1ab7c8e7-fb50-4e5d-b153-372f853514cf",
     "inediblePart": 0.2,
-    "landOccupation": 2.8,
+    "landOccupation": 2.80125,
     "name": "Haricot flageolet UE",
     "processId": "d21e3ed0-01e3-5f17-955f-10171826a34a",
     "rawToCookedRatio": 2.33,
@@ -4316,12 +4316,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.7,
-      "plotSize": 1.75
+      "hedges": 0.70031,
+      "plotSize": 1.7508
     },
     "id": "b5c5285f-8dfe-4865-bdc9-8d86b6977d14",
     "inediblePart": 0.2,
-    "landOccupation": 2.8,
+    "landOccupation": 2.80125,
     "name": "Haricot flageolet FR",
     "processId": "d21e3ed0-01e3-5f17-955f-10171826a34a",
     "rawToCookedRatio": 2.33,
@@ -4343,7 +4343,7 @@
     },
     "id": "cce078cf-3d3e-4153-a0a1-35555b2da639",
     "inediblePart": 0,
-    "landOccupation": 1.21,
+    "landOccupation": 1.20794,
     "name": "Riz basmati par défaut",
     "processId": "aeef59c5-49ea-5bb0-9bd8-185c1d9fe1fc",
     "rawToCookedRatio": 2.259,
@@ -4359,13 +4359,13 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 6.3202,
-      "hedges": 0.88408,
+      "cropDiversity": 6.3204,
+      "hedges": 0.8841,
       "plotSize": 1.3167
     },
     "id": "a98b8776-a96d-48e9-b218-976f5452907a",
     "inediblePart": 0,
-    "landOccupation": 2.63342,
+    "landOccupation": 2.6335,
     "name": "Blé tendre Bio",
     "processId": "61da7a9c-92d1-54f2-9fce-adcab5f9f43a",
     "rawToCookedRatio": 2.259,
@@ -4382,12 +4382,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.3315,
-      "plotSize": 0.44625
+      "hedges": 0.37157,
+      "plotSize": 0.50019
     },
     "id": "38788025-a65e-4edf-a92f-aab0b89b0d61",
     "inediblePart": 0,
-    "landOccupation": 1.19,
+    "landOccupation": 1.33383,
     "name": "Blé tendre FR",
     "processId": "222e8723-dee4-5279-83c5-65b1b1e9abbf",
     "rawToCookedRatio": 2.259,
@@ -4426,12 +4426,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.89014,
-      "plotSize": 1.2562
+      "hedges": 0.88916,
+      "plotSize": 1.2549
     },
     "id": "28013f55-a3ce-4ae6-9a97-133ce7724ece",
     "inediblePart": 0,
-    "landOccupation": 2.01,
+    "landOccupation": 2.00777,
     "name": "Blé dur FR",
     "processId": "58c87222-b99a-52c1-9ebd-8f20e24b8822",
     "rawToCookedRatio": 2.259,
@@ -4475,7 +4475,7 @@
     },
     "id": "2e196834-d2b1-4786-9265-db4440c8517c",
     "inediblePart": 0,
-    "landOccupation": 3.37552,
+    "landOccupation": 3.37551,
     "name": "Blé dur par défaut",
     "processId": "5d728287-85a3-5b30-a82b-b0bc12fcef5e",
     "rawToCookedRatio": 2.259,
@@ -4491,13 +4491,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.23864,
-      "hedges": 0.27143,
-      "plotSize": 0.3325
+      "cropDiversity": 0.27428,
+      "hedges": 0.31196,
+      "plotSize": 0.38215
     },
     "id": "3d3fc6bd-0a43-462b-bc39-fed04cf34498",
     "inediblePart": 0.1,
-    "landOccupation": 0.38,
+    "landOccupation": 0.436748,
     "name": "Pomme Bio",
     "processId": "0beb4cce-479f-588c-a8ae-27a5af4d61a5",
     "rawToCookedRatio": 0.856,
@@ -4513,13 +4513,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.35112,
-      "hedges": 0.16557,
-      "plotSize": 0.3325
+      "cropDiversity": 0.22621,
+      "hedges": 0.10667,
+      "plotSize": 0.21421
     },
     "id": "d9519b9d-d166-4bb0-8f34-27bb874b104a",
     "inediblePart": 0.1,
-    "landOccupation": 0.38,
+    "landOccupation": 0.244814,
     "name": "Pomme FR",
     "processId": "cf93fb65-5f08-5834-804f-fb8d0c9e13d0",
     "rawToCookedRatio": 0.856,
@@ -4535,13 +4535,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 1.3227,
-      "hedges": 0.27321,
-      "plotSize": 0.41319
+      "cropDiversity": 1.4026,
+      "hedges": 0.28973,
+      "plotSize": 0.43816
     },
     "id": "5ba9ada3-0712-42c4-a13c-a5c5df639943",
     "inediblePart": 0.1,
-    "landOccupation": 0.472212,
+    "landOccupation": 0.500759,
     "name": "Pomme de terre de table Bio",
     "processId": "16ef7087-994f-5773-bee1-ed702e8cfafa",
     "rawToCookedRatio": 0.856,
@@ -4557,13 +4557,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 1.3172,
-      "hedges": 0.27209,
-      "plotSize": 0.41149
+      "cropDiversity": 1.4014,
+      "hedges": 0.28947,
+      "plotSize": 0.43779
     },
     "id": "f839b523-b133-430f-9533-419b862e69e9",
     "inediblePart": 0.1,
-    "landOccupation": 0.470272,
+    "landOccupation": 0.500327,
     "name": "Pomme de terre industrie Bio",
     "processId": "8f8d7cb1-c0f2-58aa-815b-52c04bb50e89",
     "rawToCookedRatio": 0.856,
@@ -4579,13 +4579,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.38044,
-      "hedges": 0.43272,
-      "plotSize": 0.53008
+      "cropDiversity": 0.43185,
+      "hedges": 0.49119,
+      "plotSize": 0.6017
     },
     "id": "7a04d33d-fb27-41f8-bbb3-85dc5662f24c",
     "inediblePart": 0.1,
-    "landOccupation": 0.605803,
+    "landOccupation": 0.687662,
     "name": "Kiwi Bio",
     "processId": "3fe25ce7-6316-5e3f-94df-c617f0d29be6",
     "rawToCookedRatio": 0.856,
@@ -4601,13 +4601,13 @@
     "defaultOrigin": "France",
     "density": 0.362,
     "ecosystemicServices": {
-      "cropDiversity": 0.36755,
-      "hedges": 0.07592,
-      "plotSize": 0.11482
+      "cropDiversity": 0.41275,
+      "hedges": 0.085257,
+      "plotSize": 0.12894
     },
     "id": "ba292cce-6815-45e3-be3e-ed34a3b04a6f",
     "inediblePart": 0.2,
-    "landOccupation": 0.13122,
+    "landOccupation": 0.147358,
     "name": "Chou rouge Bio",
     "processId": "74fb0fdb-d880-56d8-9a1f-0357daafcfe6",
     "rawToCookedRatio": 0.856,
@@ -4623,13 +4623,13 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 0.12908,
-      "hedges": 0.028813,
-      "plotSize": 0.066596
+      "cropDiversity": 0.13659,
+      "hedges": 0.030488,
+      "plotSize": 0.070468
     },
     "id": "83ef3fba-9359-4f51-9f10-234c0e940b88",
     "inediblePart": 0,
-    "landOccupation": 0.0761094,
+    "landOccupation": 0.0805347,
     "name": "Betterave sucrière Bio",
     "processId": "f9b0f39b-df02-5943-b183-5bf7c178b5fe",
     "rawToCookedRatio": 1.0,
@@ -4645,13 +4645,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.10926,
-      "hedges": 0.12427,
-      "plotSize": 0.15224
+      "cropDiversity": 0.1187,
+      "hedges": 0.13501,
+      "plotSize": 0.16539
     },
     "id": "8eec6aa3-2234-468c-aa5a-cfb364285ac9",
     "inediblePart": 0.2,
-    "landOccupation": 0.173983,
+    "landOccupation": 0.18902,
     "name": "Papaye Bio",
     "processId": "1dcbc55f-c12e-5ff1-b3b0-4ac1427a8e72",
     "rawToCookedRatio": 1.0,
@@ -4667,13 +4667,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.076711,
-      "hedges": 0.015845,
-      "plotSize": 0.023964
+      "cropDiversity": 0.25352,
+      "hedges": 0.052368,
+      "plotSize": 0.079198
     },
     "id": "b43ae38e-a9f6-4272-b258-14faea6ec795",
     "inediblePart": 0.03,
-    "landOccupation": 0.0273869,
+    "landOccupation": 0.0905117,
     "name": "Tomate Bio",
     "processId": "3c203e41-2b6d-5bdb-bbde-0f8b706bf128",
     "rawToCookedRatio": 0.856,
@@ -4689,13 +4689,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.575,
     "ecosystemicServices": {
-      "cropDiversity": 0.17071,
-      "hedges": 0.19417,
-      "plotSize": 0.23785
+      "cropDiversity": 0.17208,
+      "hedges": 0.19573,
+      "plotSize": 0.23977
     },
     "id": "0f52bae1-07d0-446d-ae5b-f246f894ac3b",
     "inediblePart": 0.5,
-    "landOccupation": 0.271833,
+    "landOccupation": 0.274019,
     "name": "Ananas Bio",
     "processId": "0050f67f-5cb7-552c-af06-2d5f824112fc",
     "rawToCookedRatio": 0.856,
@@ -4711,13 +4711,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 13.256,
-      "hedges": 2.7381,
-      "plotSize": 4.1409
+      "cropDiversity": 13.539,
+      "hedges": 2.7966,
+      "plotSize": 4.2295
     },
     "id": "74a016ae-d486-4766-adfd-e44697b7be2f",
     "inediblePart": 0.2,
-    "landOccupation": 4.73249,
+    "landOccupation": 4.83366,
     "name": "Petit pois Bio",
     "processId": "13e48bf9-dc12-5925-9044-e33a63c37f80",
     "rawToCookedRatio": 2.33,
@@ -4734,12 +4734,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.7035,
-      "plotSize": 4.9686
+      "hedges": 1.7442,
+      "plotSize": 5.0872
     },
     "id": "b97e29ab-81b0-478e-b73b-4113aaf68470",
     "inediblePart": 0.5,
-    "landOccupation": 5.67836,
+    "landOccupation": 5.81392,
     "name": "Amandes en coque Bio",
     "processId": "5f01b49c-e4b2-52cd-9d50-30a8f6c3c711",
     "rawToCookedRatio": 1.0,
@@ -4755,13 +4755,13 @@
     "defaultOrigin": "France",
     "density": 0.118,
     "ecosystemicServices": {
-      "cropDiversity": 0.087837,
-      "hedges": 0.018144,
-      "plotSize": 0.027439
+      "cropDiversity": 0.24636,
+      "hedges": 0.050889,
+      "plotSize": 0.076961
     },
     "id": "83adcc36-72b1-4bff-b7bb-c6ac6f2a4a0b",
     "inediblePart": 0.4,
-    "landOccupation": 0.0313593,
+    "landOccupation": 0.0879558,
     "name": "Laitue Bio",
     "processId": "a5cc09cd-2ee4-523f-92c3-c24efdfc2fd6",
     "rawToCookedRatio": 0.856,
@@ -4777,13 +4777,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghrebByPlane",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.52555,
-      "hedges": 0.59776,
-      "plotSize": 0.73226
+      "cropDiversity": 0.5288,
+      "hedges": 0.60146,
+      "plotSize": 0.73679
     },
     "id": "ef57c898-8780-48cb-b00f-7d8a310f46aa",
     "inediblePart": 0.2,
-    "landOccupation": 0.836863,
+    "landOccupation": 0.842044,
     "name": "Mangue Bio",
     "processId": "ce81ca82-6b0d-5bb0-a744-205595d8079c",
     "rawToCookedRatio": 0.856,
@@ -4799,13 +4799,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.52555,
-      "hedges": 0.59776,
-      "plotSize": 0.73226
+      "cropDiversity": 0.5288,
+      "hedges": 0.60146,
+      "plotSize": 0.73679
     },
     "id": "03ecc69a-01a4-4ca2-83ba-77e8310d034a",
     "inediblePart": 0.2,
-    "landOccupation": 0.836863,
+    "landOccupation": 0.842044,
     "name": "Litchi Bio",
     "processId": "ce81ca82-6b0d-5bb0-a744-205595d8079c",
     "rawToCookedRatio": 0.856,
@@ -4827,7 +4827,7 @@
     },
     "id": "e9764c3c-554f-4f1e-9ba1-8debc869e6ba",
     "inediblePart": 0.2,
-    "landOccupation": 1.78732,
+    "landOccupation": 0.410125,
     "name": "Litchi par défaut",
     "processId": "7593f9cb-9e30-57de-8d56-3f34fe6c70ea",
     "rawToCookedRatio": 0.856,
@@ -4849,7 +4849,7 @@
     },
     "id": "94c4be9e-452d-4870-b1a2-5d2404a0490b",
     "inediblePart": 0,
-    "landOccupation": 1.75867,
+    "landOccupation": 1.76034,
     "name": "Avoine par défaut",
     "processId": "e1c15b25-68bd-5019-a24f-977dcdd42c37",
     "rawToCookedRatio": 2.259,
@@ -4865,13 +4865,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 3.4686,
-      "hedges": 1.2007,
-      "plotSize": 1.4798
+      "cropDiversity": 3.4688,
+      "hedges": 1.2008,
+      "plotSize": 1.4799
     },
     "id": "1af0933a-0139-480c-832d-053513d0ccba",
     "inediblePart": 0,
-    "landOccupation": 2.36763,
+    "landOccupation": 2.36777,
     "name": "Avoine Bio",
     "processId": "d3eb6018-2a94-568c-bc3b-dfc997764b1d",
     "rawToCookedRatio": 2.259,
@@ -4888,12 +4888,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.38481,
-      "plotSize": 0.56118
+      "hedges": 0.38485,
+      "plotSize": 0.56125
     },
     "id": "ab087863-f311-4066-8e93-4d7f6e0db2b2",
     "inediblePart": 0,
-    "landOccupation": 1.49649,
+    "landOccupation": 1.49666,
     "name": "Orge FR",
     "processId": "07dd9feb-f35b-5d86-8369-64a54df35be4",
     "rawToCookedRatio": 2.259,
@@ -4909,13 +4909,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 6.3479,
-      "hedges": 1.1578,
-      "plotSize": 1.8091
+      "cropDiversity": 6.348,
+      "hedges": 1.1579,
+      "plotSize": 1.8092
     },
     "id": "3c16dc23-021d-45ef-8805-c77b043b041a",
     "inediblePart": 0,
-    "landOccupation": 2.8946,
+    "landOccupation": 2.89468,
     "name": "Orge Bio",
     "processId": "cddd4ef4-9810-5e9f-890f-846a05c9c285",
     "rawToCookedRatio": 2.259,
@@ -4931,13 +4931,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.31852,
-      "hedges": 0.36228,
-      "plotSize": 0.44379
+      "cropDiversity": 0.3324,
+      "hedges": 0.37807,
+      "plotSize": 0.46313
     },
     "id": "b3f92ca9-3121-4e2d-9e1d-0cc2c5d392fe",
     "inediblePart": 0.3,
-    "landOccupation": 0.50719,
+    "landOccupation": 0.529292,
     "name": "Banane Bio",
     "processId": "6adbf7fa-1de0-5251-a324-5d63f2aabcb8",
     "rawToCookedRatio": 0.856,
@@ -4953,13 +4953,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 0.575,
     "ecosystemicServices": {
-      "cropDiversity": 0.23322,
-      "hedges": 0.26526,
-      "plotSize": 0.32495
+      "cropDiversity": 0.24155,
+      "hedges": 0.27474,
+      "plotSize": 0.33655
     },
     "id": "1716c0e6-7a04-4649-a71f-08a495eb094e",
     "inediblePart": 0.2,
-    "landOccupation": 0.37137,
+    "landOccupation": 0.38463,
     "name": "Orange Bio",
     "processId": "bbb1f24f-5a84-577c-9fcb-80bb9fa3e92b",
     "rawToCookedRatio": 0.856,
@@ -4975,13 +4975,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 0.575,
     "ecosystemicServices": {
-      "cropDiversity": 0.1891,
-      "hedges": 0.21508,
-      "plotSize": 0.26347
+      "cropDiversity": 0.19256,
+      "hedges": 0.21902,
+      "plotSize": 0.2683
     },
     "id": "ed5c98fd-6fe5-43ca-b938-1dde919794b7",
     "inediblePart": 0.3,
-    "landOccupation": 0.301111,
+    "landOccupation": 0.306629,
     "name": "Citron Bio",
     "processId": "ed602e82-ac82-5b0a-b953-3661f168f045",
     "rawToCookedRatio": 0.856,
@@ -4997,13 +4997,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.37814,
-      "hedges": 0.078107,
-      "plotSize": 0.11813
+      "cropDiversity": 0.43039,
+      "hedges": 0.088901,
+      "plotSize": 0.13445
     },
     "id": "16efe840-56d1-4baa-9c14-7eabd1fb510f",
     "inediblePart": 0.03,
-    "landOccupation": 0.135,
+    "landOccupation": 0.153655,
     "name": "Céleri branche Bio",
     "processId": "bbcc33a9-2e2a-5088-b436-4a05add6f8cb",
     "rawToCookedRatio": 0.856,
@@ -5020,12 +5020,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.5824,
-      "plotSize": 3.1777
+      "hedges": 1.5995,
+      "plotSize": 3.2121
     },
     "id": "25543778-46ab-419e-a7d8-5c0cd37d8dbd",
     "inediblePart": 0.5,
-    "landOccupation": 3.63165,
+    "landOccupation": 3.67099,
     "name": "Olive Bio",
     "processId": "bd0ce307-8af5-5a04-b7d5-be0ec2f6913a",
     "rawToCookedRatio": 1.0,
@@ -5042,12 +5042,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.569,
-      "plotSize": 4.5761
+      "hedges": 1.7948,
+      "plotSize": 5.2348
     },
     "id": "9dec26dd-bf7c-4336-996e-3f9bd8659d05",
     "inediblePart": 0.5,
-    "landOccupation": 5.22988,
+    "landOccupation": 5.98268,
     "name": "Arachide avec coque Bio",
     "processId": "048fd4c5-6b27-5701-a06c-8f4570bf6b6f",
     "rawToCookedRatio": 1.0,
@@ -5063,13 +5063,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 9.0431,
-      "hedges": 1.8679,
-      "plotSize": 2.825
+      "cropDiversity": 10.397,
+      "hedges": 2.1476,
+      "plotSize": 3.2479
     },
     "id": "091cda9d-3c9d-444c-ad0e-1d6f34491767",
     "inediblePart": 0.03,
-    "landOccupation": 3.22853,
+    "landOccupation": 3.71186,
     "name": "Framboise Bio",
     "processId": "305b88b9-da4d-5573-a534-4f964a7e8c18",
     "rawToCookedRatio": 0.856,
@@ -5085,13 +5085,13 @@
     "defaultOrigin": "France",
     "density": 0.118,
     "ecosystemicServices": {
-      "cropDiversity": 0.087837,
-      "hedges": 0.018144,
-      "plotSize": 0.027439
+      "cropDiversity": 0.24636,
+      "hedges": 0.050889,
+      "plotSize": 0.076961
     },
     "id": "a8b2bd23-e7af-4311-b163-ff3834b96f9f",
     "inediblePart": 0.4,
-    "landOccupation": 0.0313593,
+    "landOccupation": 0.0879558,
     "name": "Mâche Bio",
     "processId": "a5cc09cd-2ee4-523f-92c3-c24efdfc2fd6",
     "rawToCookedRatio": 0.856,
@@ -5107,13 +5107,13 @@
     "defaultOrigin": "France",
     "density": 0.118,
     "ecosystemicServices": {
-      "cropDiversity": 0.087837,
-      "hedges": 0.018144,
-      "plotSize": 0.027439
+      "cropDiversity": 0.24636,
+      "hedges": 0.050889,
+      "plotSize": 0.076961
     },
     "id": "6842d570-6b53-49f3-ba9c-984b55e40171",
     "inediblePart": 0.2,
-    "landOccupation": 0.0313593,
+    "landOccupation": 0.0879558,
     "name": "Endive Bio",
     "processId": "a5cc09cd-2ee4-523f-92c3-c24efdfc2fd6",
     "rawToCookedRatio": 0.856,
@@ -5129,13 +5129,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 3.7814,
-      "hedges": 1.309,
-      "plotSize": 1.6132
+      "cropDiversity": 3.8882,
+      "hedges": 1.346,
+      "plotSize": 1.6588
     },
     "id": "590e5fc8-26fd-4cea-9737-86bc3aa6af8d",
     "inediblePart": 0,
-    "landOccupation": 2.58113,
+    "landOccupation": 2.65408,
     "name": "Blé dur Bio",
     "processId": "1fa5eaea-5cad-59b4-930c-9092e2a54c56",
     "rawToCookedRatio": 2.259,
@@ -5151,13 +5151,13 @@
     "defaultOrigin": "France",
     "density": 0.6195,
     "ecosystemicServices": {
-      "cropDiversity": 0.7955,
-      "hedges": 0.16432,
-      "plotSize": 0.24851
+      "cropDiversity": 0.82427,
+      "hedges": 0.17026,
+      "plotSize": 0.25749
     },
     "id": "752f4a99-f85b-4bb8-9a8b-139d1f08a4b0",
     "inediblePart": 0.1,
-    "landOccupation": 0.284007,
+    "landOccupation": 0.294277,
     "name": "Oignon Bio",
     "processId": "1da54124-594f-5053-b788-4c3c99b6d1cd",
     "rawToCookedRatio": 0.856,
@@ -5174,12 +5174,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.19092,
-      "plotSize": 0.17585
+      "hedges": 0.2055,
+      "plotSize": 0.18928
     },
     "id": "dcdcb4d1-1793-4f1b-bd1f-7578d02e4fb1",
     "inediblePart": 0,
-    "landOccupation": 1.40676,
+    "landOccupation": 1.51421,
     "name": "Riz basmati Bio",
     "processId": "cb474038-056f-5fd6-a3a2-01c8e928657c",
     "rawToCookedRatio": 2.259,
@@ -5195,13 +5195,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 4.6388,
-      "hedges": 1.6058,
-      "plotSize": 1.979
+      "cropDiversity": 4.6389,
+      "hedges": 1.6059,
+      "plotSize": 1.9791
     },
     "id": "585c8bb1-1aaa-4c33-a5c1-84c886bb7ec3",
     "inediblePart": 0,
-    "landOccupation": 3.16642,
+    "landOccupation": 3.16648,
     "name": "Triricale Bio",
     "processId": "72214808-e218-567f-ae89-d0cee404ab8b",
     "rawToCookedRatio": 2.259,
@@ -5217,13 +5217,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 4.1356,
-      "hedges": 1.4316,
+      "cropDiversity": 4.1357,
+      "hedges": 1.4317,
       "plotSize": 1.7644
     },
     "id": "8cf0b0ce-7ae7-4123-8fee-823b4c190418",
     "inediblePart": 0,
-    "landOccupation": 2.82296,
+    "landOccupation": 2.823,
     "name": "Pois Bio",
     "processId": "5de7df4a-068c-56eb-a34d-e114264aeba1",
     "rawToCookedRatio": 2.259,
@@ -5239,13 +5239,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 2.2036,
-      "hedges": 0.76283,
-      "plotSize": 0.94011
+      "cropDiversity": 2.2038,
+      "hedges": 0.76288,
+      "plotSize": 0.94018
     },
     "id": "fd187fa6-9cbc-4839-b13f-365c5371cee6",
     "inediblePart": 0,
-    "landOccupation": 1.50418,
+    "landOccupation": 1.50428,
     "name": "Luzerne Bio",
     "processId": "909d58a0-585c-550b-95e4-2975ed6192f4",
     "rawToCookedRatio": 2.259,
@@ -5261,13 +5261,13 @@
     "defaultOrigin": "France",
     "density": 0.6375,
     "ecosystemicServices": {
-      "cropDiversity": 0.092013,
-      "hedges": 0.019006,
-      "plotSize": 0.028744
+      "cropDiversity": 0.13672,
+      "hedges": 0.02824,
+      "plotSize": 0.042709
     },
     "id": "076b3d53-fc81-454b-9c90-e19767de8b0b",
     "inediblePart": 0.1,
-    "landOccupation": 0.03285,
+    "landOccupation": 0.0488102,
     "name": "Radis Bio",
     "processId": "4f982b91-4c25-5b52-b4c9-e06f0ed9fb31",
     "rawToCookedRatio": 1.0,
@@ -5283,13 +5283,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 31.683,
-      "hedges": 2.6136,
-      "plotSize": 3.9772
+      "cropDiversity": 31.817,
+      "hedges": 2.6247,
+      "plotSize": 3.9941
     },
     "id": "02b2ed63-6246-446c-8cf3-224dbe698821",
     "inediblePart": 0,
-    "landOccupation": 7.95448,
+    "landOccupation": 7.9882,
     "name": "Lentilles Bio",
     "processId": "08f62494-0ee6-55c9-af85-e09706e34ce1",
     "rawToCookedRatio": 2.33,
@@ -5305,13 +5305,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.44053,
-      "hedges": 0.50106,
-      "plotSize": 0.61379
+      "cropDiversity": 0.51789,
+      "hedges": 0.58905,
+      "plotSize": 0.72159
     },
     "id": "36158ea6-066c-4fd6-9e28-6477c7297b37",
     "inediblePart": 0.2,
-    "landOccupation": 0.701477,
+    "landOccupation": 0.824673,
     "name": "Abricot Bio",
     "processId": "f8a5b889-a03e-5fed-bbbe-43d3d8ba2dc4",
     "rawToCookedRatio": 0.856,
@@ -5327,13 +5327,13 @@
     "defaultOrigin": "France",
     "density": 0.6195,
     "ecosystemicServices": {
-      "cropDiversity": 0.40044,
-      "hedges": 0.082715,
-      "plotSize": 0.12509
+      "cropDiversity": 0.41893,
+      "hedges": 0.086535,
+      "plotSize": 0.13087
     },
     "id": "66cde9d8-28e6-4855-9a3c-1b40a6f7bba8",
     "inediblePart": 0.2,
-    "landOccupation": 0.142965,
+    "landOccupation": 0.149566,
     "name": "Poireau Bio",
     "processId": "ed4e8b3a-1571-57ee-b6e1-5c0dd1703ef3",
     "rawToCookedRatio": 0.856,
@@ -5349,13 +5349,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 16.009,
-      "hedges": 18.209,
-      "plotSize": 22.306
+      "cropDiversity": 16.041,
+      "hedges": 18.245,
+      "plotSize": 22.351
     },
     "id": "b4e8febc-6588-4599-8c58-c019144597c6",
     "inediblePart": 0.2,
-    "landOccupation": 25.4923,
+    "landOccupation": 25.5436,
     "name": "Cerise Bio",
     "processId": "7850ccc2-6ef8-5f58-832f-3b78368dfd97",
     "rawToCookedRatio": 0.856,
@@ -5371,13 +5371,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 16.009,
-      "hedges": 18.209,
-      "plotSize": 22.306
+      "cropDiversity": 16.041,
+      "hedges": 18.245,
+      "plotSize": 22.351
     },
     "id": "10af6fa1-e374-4748-b8a8-f735d2813489",
     "inediblePart": 0.2,
-    "landOccupation": 25.4923,
+    "landOccupation": 25.5436,
     "name": "Prune Bio",
     "processId": "7850ccc2-6ef8-5f58-832f-3b78368dfd97",
     "rawToCookedRatio": 0.856,
@@ -5393,13 +5393,13 @@
     "defaultOrigin": "France",
     "density": 0.6195,
     "ecosystemicServices": {
-      "cropDiversity": 0.7955,
-      "hedges": 0.16432,
-      "plotSize": 0.24851
+      "cropDiversity": 0.82427,
+      "hedges": 0.17026,
+      "plotSize": 0.25749
     },
     "id": "c224d640-c347-41c4-9754-a4cea77de16f",
     "inediblePart": 0.1,
-    "landOccupation": 0.284007,
+    "landOccupation": 0.294277,
     "name": "Echalote Bio",
     "processId": "1da54124-594f-5053-b788-4c3c99b6d1cd",
     "rawToCookedRatio": 0.856,
@@ -5415,13 +5415,13 @@
     "defaultOrigin": "OutOfEuropeAndMaghreb",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 9.3376,
-      "hedges": 1.9288,
-      "plotSize": 2.917
+      "cropDiversity": 10.684,
+      "hedges": 2.2068,
+      "plotSize": 3.3374
     },
     "id": "df1fe70a-08c0-4b8a-9f88-0caeb002d26a",
     "inediblePart": 0.03,
-    "landOccupation": 3.33367,
+    "landOccupation": 3.8142,
     "name": "Myrtille Bio",
     "processId": "81afdcc9-dbcd-5547-bf95-c97c0b0ed5fe",
     "rawToCookedRatio": 0.856,
@@ -5437,13 +5437,13 @@
     "defaultOrigin": "France",
     "density": 0.118,
     "ecosystemicServices": {
-      "cropDiversity": 0.1314,
-      "hedges": 0.027142,
-      "plotSize": 0.041048
+      "cropDiversity": 0.13788,
+      "hedges": 0.02848,
+      "plotSize": 0.043071
     },
     "id": "49ad2a72-d196-4379-8f23-212b27d44917",
     "inediblePart": 0.03,
-    "landOccupation": 0.0469125,
+    "landOccupation": 0.0492245,
     "name": "Epinard Bio",
     "processId": "c9ee9f7c-c3b9-5745-a4b1-1b0300f2e27e",
     "rawToCookedRatio": 0.856,
@@ -5459,13 +5459,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 1.4764,
-      "hedges": 0.30496,
-      "plotSize": 0.46121
+      "cropDiversity": 1.569,
+      "hedges": 0.32408,
+      "plotSize": 0.49013
     },
     "id": "d5aff6c8-470b-457b-bc67-294d8987ee5e",
     "inediblePart": 0.4,
-    "landOccupation": 0.527097,
+    "landOccupation": 0.560144,
     "name": "Pastèque Bio",
     "processId": "637422c7-b6a1-5c16-b0eb-ae039c0386d0",
     "rawToCookedRatio": 0.856,
@@ -5482,12 +5482,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.43389,
-      "plotSize": 0.44665
+      "hedges": 0.43393,
+      "plotSize": 0.44669
     },
     "id": "dc872330-8d35-4b02-bf45-4481b89a093e",
     "inediblePart": 0.5,
-    "landOccupation": 0.893299,
+    "landOccupation": 0.893381,
     "name": "Ensilage maïs FR",
     "processId": "834cc861-1bf6-5ac4-b947-a80851da4b57",
     "rawToCookedRatio": 2.259,
@@ -5503,13 +5503,13 @@
     "defaultOrigin": "France",
     "density": 0.24,
     "ecosystemicServices": {
-      "cropDiversity": 0.9326,
-      "hedges": 0.4977,
-      "plotSize": 0.44665
+      "cropDiversity": 0.93269,
+      "hedges": 0.49774,
+      "plotSize": 0.44669
     },
     "id": "305cc005-eb5c-4e94-b5cf-9aa21c619577",
     "inediblePart": 0.5,
-    "landOccupation": 0.893299,
+    "landOccupation": 0.893381,
     "name": "Ensilage maïs Bio",
     "processId": "834cc861-1bf6-5ac4-b947-a80851da4b57",
     "rawToCookedRatio": 2.259,
@@ -5531,7 +5531,7 @@
     },
     "id": "4b3c39a6-496c-416c-a42a-8d4c2fc788da",
     "inediblePart": 0,
-    "landOccupation": 1.9659,
+    "landOccupation": 1.97529,
     "name": "Soja FR",
     "processId": "1eec6669-df89-5638-92da-a7c2fb3b033a",
     "rawToCookedRatio": 2.33,
@@ -5548,12 +5548,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.81429,
-      "plotSize": 0.75
+      "hedges": 1.2197,
+      "plotSize": 1.1234
     },
     "id": "ba97e4b9-1fac-4f92-bed1-9889e3ae631d",
     "inediblePart": 0,
-    "landOccupation": 1.0,
+    "landOccupation": 1.49788,
     "name": "Herbe de prairie temporaire FR",
     "processId": "d2d9709a-b022-5283-99ac-31d1c7ebb3f1",
     "rawToCookedRatio": 1.0,
@@ -5570,12 +5570,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.76429,
-      "plotSize": 0.625
+      "hedges": 1.0365,
+      "plotSize": 0.84761
     },
     "id": "c88d387e-8435-4741-b742-0094dbdcee45",
     "inediblePart": 0,
-    "landOccupation": 1.0,
+    "landOccupation": 1.35618,
     "name": "Herbe de prairie permanente FR",
     "processId": "f1c34290-cdbe-5249-a667-dcc761059c97",
     "rawToCookedRatio": 1.0,
@@ -5597,7 +5597,7 @@
     },
     "id": "4e13ea5f-4ad1-4009-ae91-842cb18bd4dd",
     "inediblePart": 0.2,
-    "landOccupation": 1.78732,
+    "landOccupation": 1.79013,
     "name": "Cerise par défaut",
     "processId": "31f47ffb-0ac9-5140-a61e-f41246644d45",
     "rawToCookedRatio": 0.856,
@@ -5619,7 +5619,7 @@
     },
     "id": "3612e931-f0e0-4263-a079-63650a941fbd",
     "inediblePart": 0,
-    "landOccupation": 2.13557,
+    "landOccupation": 2.13646,
     "name": "Huile de palme (raffinée) UE",
     "processId": "3d90a1fd-8875-5b01-9fe2-68a1dfbdd0d0",
     "rawToCookedRatio": 1.0,
@@ -5636,12 +5636,12 @@
     "density": 0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.9966,
+      "hedges": 1.9969,
       "plotSize": 0
     },
     "id": "61ede109-0eed-4aa3-93bb-aacf132b6bdd",
     "inediblePart": 0,
-    "landOccupation": 13.976,
+    "landOccupation": 13.9781,
     "name": "Huile de lin (raffinée) FR",
     "processId": "04652154-34aa-5dbd-9c01-8557f2d844f5",
     "rawToCookedRatio": 1.0,
@@ -5658,12 +5658,12 @@
     "density": 0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.31333,
-      "plotSize": 1.0966
+      "hedges": 0.31376,
+      "plotSize": 1.0982
     },
     "id": "1e3d325d-b369-4f03-b3a3-f4261924fca4",
     "inediblePart": 0,
-    "landOccupation": 1.25331,
+    "landOccupation": 1.25506,
     "name": "Huile de pépin de raisin (raffinée) FR",
     "processId": "d42c72e6-6043-521b-be15-d10efb920e7a",
     "rawToCookedRatio": 1.0,
@@ -5685,7 +5685,7 @@
     },
     "id": "188a3d66-f214-4821-9bac-7e8fdc715721",
     "inediblePart": 0,
-    "landOccupation": 7.45491,
+    "landOccupation": 7.45682,
     "name": "Huile de soja (raffinée) FR",
     "processId": "3d2e9c5d-6088-5df4-8e6d-620655d82347",
     "rawToCookedRatio": 1.0,
@@ -5707,7 +5707,7 @@
     },
     "id": "00603559-120a-4aa4-b12b-2eda1705e064",
     "inediblePart": 0,
-    "landOccupation": 28.7167,
+    "landOccupation": 28.723,
     "name": "Huile de noisette (vierge) FR",
     "processId": "17bc5b5f-b1fe-5877-9a4d-3512b6aa50e7",
     "rawToCookedRatio": 1.0,
@@ -5729,7 +5729,7 @@
     },
     "id": "c704400c-9108-49a8-a79a-b830eccb6b5e",
     "inediblePart": 0,
-    "landOccupation": 15.0431,
+    "landOccupation": 15.047,
     "name": "Huile d'arachide (raffinée) par défaut",
     "processId": "c66c23ee-1aaf-59cc-b32b-7f05ab81fdf1",
     "rawToCookedRatio": 1.0,
@@ -5751,7 +5751,7 @@
     },
     "id": "583d00ab-0340-444b-9581-71175f0a937b",
     "inediblePart": 0,
-    "landOccupation": 10.4129,
+    "landOccupation": 10.4138,
     "name": "Huile de tournesol (raffinée) FR",
     "processId": "41e46719-7326-5dbd-a494-142e83e497d7",
     "rawToCookedRatio": 1.0,
@@ -5768,12 +5768,12 @@
     "density": 0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.0753,
-      "plotSize": 1.1761
+      "hedges": 1.0755,
+      "plotSize": 1.1763
     },
     "id": "c3697176-e682-43c3-b16a-3992ff8f1404",
     "inediblePart": 0,
-    "landOccupation": 4.7043,
+    "landOccupation": 4.70538,
     "name": "Huile de colza (raffinée) FR",
     "processId": "beddeba8-490f-5019-ac1e-a8d3bf1f062a",
     "rawToCookedRatio": 1.0,
@@ -5795,7 +5795,7 @@
     },
     "id": "fbe48b5b-62f2-4ccb-8aa6-66d08a4c7fac",
     "inediblePart": 0,
-    "landOccupation": 11.5458,
+    "landOccupation": 11.5482,
     "name": "Huile d'olive (extra vierge) UE",
     "processId": "7a903fb2-264d-5c54-8269-c5d13d95f4ac",
     "rawToCookedRatio": 1.0,
@@ -5811,7 +5811,7 @@
     "density": 1.0,
     "id": "2cced940-3abf-439d-b2f1-e6241ffb31fd",
     "inediblePart": 0,
-    "landOccupation": 2.09036,
+    "landOccupation": 2.09033,
     "name": "Crème fraiche FR",
     "processId": "3a74e4f9-7a51-59a1-a393-2889537c9901",
     "rawToCookedRatio": 1.0,
@@ -5827,7 +5827,7 @@
     "density": 1.0,
     "id": "8b6fda86-052a-49eb-90fb-53e307544150",
     "inediblePart": 0,
-    "landOccupation": 3.69576,
+    "landOccupation": 3.69808,
     "name": "Oeuf cru décoquillé FR",
     "processId": "f9af949f-58ec-5608-abaf-772d7e190f38",
     "rawToCookedRatio": 0.974,
@@ -5843,7 +5843,7 @@
     "density": 1.0,
     "id": "f6e84334-a8bb-4f07-915d-ef51e8dcf800",
     "inediblePart": 0,
-    "landOccupation": 3.70244,
+    "landOccupation": 3.70517,
     "name": "poudre de jaune d'oeuf FR",
     "processId": "a34007f4-d4a4-562c-84a9-68360af1026a",
     "rawToCookedRatio": 1.0,
@@ -5859,7 +5859,7 @@
     "density": 1.0,
     "id": "7fe451fd-77c8-46f3-b7ae-c050a08b7be8",
     "inediblePart": 0,
-    "landOccupation": 3.70299,
+    "landOccupation": 3.70572,
     "name": "poudre de blanc d'oeuf FR",
     "processId": "71637452-abfa-574b-a06e-0dd6f064246d",
     "rawToCookedRatio": 1.0,
@@ -5875,7 +5875,7 @@
     "density": 1.0,
     "id": "bd6e16d9-588d-48df-9eab-e0c4c64f5c53",
     "inediblePart": 0,
-    "landOccupation": 6.67983,
+    "landOccupation": 6.68229,
     "name": "Emmental rapé FR",
     "processId": "13a81bef-4db1-58d6-970b-f632566e504a",
     "rawToCookedRatio": 1.0,
@@ -5897,7 +5897,7 @@
     },
     "id": "3d7f808b-77c5-4207-968d-feea6dfd9496",
     "inediblePart": 0,
-    "landOccupation": 11.9277,
+    "landOccupation": 11.9296,
     "name": "Poudre de cacao par défaut",
     "processId": "04e64cd5-d278-50eb-9085-a80d4db90920",
     "rawToCookedRatio": 1.0,
@@ -5935,14 +5935,14 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.52145,
+      "hedges": 1.63338,
       "livestockDensity": -0.027132,
       "permanentPasture": 0,
-      "plotSize": 1.95818
+      "plotSize": 2.10883
     },
     "id": "f3537dee-a80a-4b6f-9942-16b3f9e21101",
     "inediblePart": 0,
-    "landOccupation": 7.00414,
+    "landOccupation": 7.00383,
     "name": "Poitrine de porc FR",
     "processId": "17225d3f-0489-54f4-9c06-c8c515ca9f16",
     "rawToCookedRatio": 1.0,
@@ -5981,10 +5981,10 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.47658,
+      "hedges": 1.5789,
       "livestockDensity": -0.027132,
       "permanentPasture": 0,
-      "plotSize": 1.89174
+      "plotSize": 2.02945
     },
     "id": "6fb662dc-583f-47d5-814f-2cc6a8c1f3b9",
     "inediblePart": 0,
@@ -6003,11 +6003,11 @@
     "defaultOrigin": "France",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 26.2965,
-      "hedges": 6.91387,
+      "cropDiversity": 26.2971,
+      "hedges": 6.91433,
       "livestockDensity": -0.007803,
       "permanentPasture": 0,
-      "plotSize": 9.13148
+      "plotSize": 9.13176
     },
     "id": "b78a8267-2304-44a1-be1b-f3a4432bfdf7",
     "inediblePart": 0,
@@ -6033,7 +6033,7 @@
     },
     "id": "06dffb5c-07ad-48de-9630-632f4c84e02d",
     "inediblePart": 0,
-    "landOccupation": 1.26874,
+    "landOccupation": 1.26873,
     "name": "Sirop de glucose FR ou UE ou par défaut",
     "processId": "3d653688-83e2-56ce-8419-005564784e3e",
     "rawToCookedRatio": 1.0,
@@ -6049,13 +6049,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.35877,
-      "hedges": 0.16918,
-      "plotSize": 0.33975
+      "cropDiversity": 0.35875,
+      "hedges": 0.16917,
+      "plotSize": 0.33973
     },
     "id": "f51ef7f1-9d4c-4c4a-a4a6-c011c520f419",
     "inediblePart": 0,
-    "landOccupation": 0.388281,
+    "landOccupation": 0.38826,
     "name": "Compote de pomme FR",
     "processId": "63ac7fd9-6bf5-5cd2-ad90-2286b0916e8e",
     "rawToCookedRatio": 0.856,
@@ -6071,7 +6071,7 @@
     "density": 1.0,
     "id": "a9eed813-3242-4701-8d76-f4fb2f222121",
     "inediblePart": 0,
-    "landOccupation": 1.93317,
+    "landOccupation": 1.9331,
     "name": "Lait de chèvre FR",
     "processId": "41428d85-058c-588c-8eb0-b12f2f922fb0",
     "rawToCookedRatio": 1.0,
@@ -6088,12 +6088,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 1.5241,
-      "plotSize": 2.151
+      "hedges": 1.4753,
+      "plotSize": 2.082
     },
     "id": "1508af02-c164-4189-9fac-0057566e0950",
     "inediblePart": 0,
-    "landOccupation": 3.44156,
+    "landOccupation": 3.33127,
     "name": "Mélange de céréales FR",
     "processId": "c2a948c2-dfdd-582f-88a3-f2217e8377fd",
     "rawToCookedRatio": 2.259,
@@ -6110,12 +6110,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.13749,
-      "plotSize": 1.4436
+      "hedges": 0.13748,
+      "plotSize": 1.4435
     },
     "id": "06e7ba46-85ba-4475-82d2-a59f847e801d",
     "inediblePart": 0.2,
-    "landOccupation": 3.84961,
+    "landOccupation": 3.8494,
     "name": "Pâtes FR",
     "processId": "0da8ba31-b350-5aa0-a1cb-77a2d1695f30",
     "rawToCookedRatio": 2.259,
@@ -6132,12 +6132,12 @@
     "density": 0.6195,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.0095332,
-      "plotSize": 0.1001
+      "hedges": 0.0095327,
+      "plotSize": 0.10009
     },
     "id": "06f219a1-ffb3-44ae-ba23-6f9ad7baff39",
     "inediblePart": 0.1,
-    "landOccupation": 0.266929,
+    "landOccupation": 0.266916,
     "name": "Ail FR",
     "processId": "f3b9be39-06cd-5886-a7da-57aaeb45a013",
     "rawToCookedRatio": 1.0,
@@ -6154,12 +6154,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.27981,
-      "plotSize": 0.69951
+      "hedges": 0.086615,
+      "plotSize": 0.21654
     },
     "id": "5ecb6c61-0a0f-4c00-a8e0-713c97929c7c",
     "inediblePart": 0,
-    "landOccupation": 1.11922,
+    "landOccupation": 0.34646,
     "name": "Mélange de légumes",
     "processId": "8927c220-d637-5d12-b0f9-5954d61e2923",
     "rawToCookedRatio": 0.856,
@@ -6175,7 +6175,7 @@
     "density": 1.0,
     "id": "ad4e4cff-9333-4f5a-bfc5-028cfe888072",
     "inediblePart": 0,
-    "landOccupation": 17.5838,
+    "landOccupation": 17.583,
     "name": "Sauce tomate à la viande FR",
     "processId": "4dc36e0c-321b-5b21-8509-42fee9fdcdb3",
     "rawToCookedRatio": 0.856,
@@ -6193,11 +6193,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.035163,
-      "plotSize": 0.36922
+      "plotSize": 0.36921
     },
     "id": "87accb8f-37c1-4364-873a-5e8e67fd5811",
     "inediblePart": 0,
-    "landOccupation": 0.984574,
+    "landOccupation": 0.98457,
     "name": "Miel FR",
     "processId": "7fd3aa2c-0c10-5165-b3ee-d3873e16dd41",
     "rawToCookedRatio": 1.0,
@@ -6213,7 +6213,7 @@
     "density": 1.0,
     "id": "b5395f5f-e011-4c65-9a6c-85dd77d10d2c",
     "inediblePart": 0,
-    "landOccupation": 4.84218,
+    "landOccupation": 4.8421,
     "name": "Viande de dinde FR",
     "processId": "ab40129d-3ebc-528c-a17b-c03a015d5c28",
     "rawToCookedRatio": 0.755,
@@ -6229,7 +6229,7 @@
     "density": 1.0,
     "id": "dc2e130a-06c1-4859-a9ca-17456de99812",
     "inediblePart": 0,
-    "landOccupation": 1.65073,
+    "landOccupation": 1.65063,
     "name": "Foie de porc cru FR",
     "processId": "56232d55-7a3f-507a-adb0-b7833b924820",
     "rawToCookedRatio": 0.73,
@@ -6245,7 +6245,7 @@
     "density": 1.0,
     "id": "33d2f3c2-ffa2-4b96-811e-50c1c8670e26",
     "inediblePart": 0,
-    "landOccupation": 0.0558186,
+    "landOccupation": 0.0558178,
     "name": "Poudre de lactosérum FR",
     "processId": "e8590810-7dc7-57d9-8a06-25e5d358bf89",
     "rawToCookedRatio": 1.0,
@@ -6262,12 +6262,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.59838,
-      "plotSize": 1.496
+      "hedges": 0.11603,
+      "plotSize": 0.29008
     },
     "id": "dd6ebd55-dc52-4e9e-ac79-aa3ed4b3295d",
     "inediblePart": 0.03,
-    "landOccupation": 2.39353,
+    "landOccupation": 0.464132,
     "name": "Purée de fraise FR",
     "processId": "538bfa96-6e80-585e-bd5e-8b73c7aeb771",
     "rawToCookedRatio": 0.856,
@@ -6299,7 +6299,7 @@
     "density": 1.0,
     "id": "d93c2c58-8073-47ef-99da-999ad7cba846",
     "inediblePart": 0,
-    "landOccupation": 9.2816,
+    "landOccupation": 9.28115,
     "name": "Fromage de chèvre FR",
     "processId": "38a4132b-9bae-58be-a943-d9b647ccc0ff",
     "rawToCookedRatio": 1.0,
@@ -6321,7 +6321,7 @@
     },
     "id": "0ea5f5a0-51d9-41da-9ac4-cb60f3ddb86c",
     "inediblePart": 0,
-    "landOccupation": 19.8412,
+    "landOccupation": 11.9276,
     "name": "Beurre de cacao par défaut",
     "processId": "db3318dc-c27c-5fb4-aa8a-8264e7d48017",
     "rawToCookedRatio": 1.0,
@@ -6343,7 +6343,7 @@
     },
     "id": "f8fb04c1-c207-4a3c-993f-e5a1b0204dfa",
     "inediblePart": 0,
-    "landOccupation": 2.65457,
+    "landOccupation": 2.65455,
     "name": "Protéines de soja par défaut",
     "processId": "2eb6a813-318a-54d1-a3ea-920fe5ae83e1",
     "rawToCookedRatio": 1.0,
@@ -6381,7 +6381,7 @@
     "density": 1.0,
     "id": "221cd239-f1ae-4a2f-9fdc-dc73df5f95ab",
     "inediblePart": 0,
-    "landOccupation": 21.4548,
+    "landOccupation": 21.4533,
     "name": "Viande de veau FR",
     "processId": "24de0bc6-1df2-5c84-bfef-d03b4f5192c7",
     "rawToCookedRatio": 0.792,
@@ -6398,12 +6398,12 @@
     "density": 0.6375,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.028066,
-      "plotSize": 0.075563
+      "hedges": 0.028065,
+      "plotSize": 0.075559
     },
     "id": "7c742241-9678-4a46-972b-8be1baf7f5a7",
     "inediblePart": 0.1,
-    "landOccupation": 0.302252,
+    "landOccupation": 0.302236,
     "name": "Frites de pomme de terre congelées FR",
     "processId": "d5f80a46-55a5-56f8-b999-762d1ad0d208",
     "rawToCookedRatio": 0.856,
@@ -6420,12 +6420,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.45186,
+      "hedges": 0.45185,
       "plotSize": 1.1296
     },
     "id": "bdae67c5-ac20-417b-9094-8755ae1ab42b",
     "inediblePart": 0,
-    "landOccupation": 1.80742,
+    "landOccupation": 1.8074,
     "name": "Sauce tomate FR",
     "processId": "b4216a81-55d0-5372-a6fd-530234e1045b",
     "rawToCookedRatio": 0.856,
@@ -6442,12 +6442,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.90357,
-      "plotSize": 2.181
+      "hedges": 0.90346,
+      "plotSize": 2.1808
     },
     "id": "d87bdd32-d698-4044-ae20-15b96c65f680",
     "inediblePart": 0.1,
-    "landOccupation": 4.36205,
+    "landOccupation": 4.36151,
     "name": "Moutarde FR",
     "processId": "6c4df747-e40f-5d39-8dbc-05806830275b",
     "rawToCookedRatio": 0.856,
@@ -6485,7 +6485,7 @@
     "density": 1.0,
     "id": "d56d21c0-0705-45e3-830d-504d63d581e0",
     "inediblePart": 0,
-    "landOccupation": 5.58135,
+    "landOccupation": 5.58127,
     "name": "Brie FR",
     "processId": "83998504-7455-5a9c-bc26-8dbe8f1ae5f4",
     "rawToCookedRatio": 1.0,
@@ -6507,7 +6507,7 @@
     },
     "id": "cfdb11f0-9ae1-47ab-a26c-20ff8444b862",
     "inediblePart": 0,
-    "landOccupation": 16.0846,
+    "landOccupation": 16.0844,
     "name": "Curcuma par défaut",
     "processId": "ed399ef5-2ccd-51c3-b027-acd9a96472b2",
     "rawToCookedRatio": 1.0,
@@ -6525,11 +6525,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.01701,
-      "plotSize": 0.17861
+      "plotSize": 0.1786
     },
     "id": "b1350dc9-f4da-4827-b984-f36b6f192c5a",
     "inediblePart": 0,
-    "landOccupation": 0.476288,
+    "landOccupation": 0.476277,
     "name": "Fruits confits FR",
     "processId": "40f68072-cb26-5034-b182-2dec509d01ef",
     "rawToCookedRatio": 1.0,
@@ -6545,7 +6545,7 @@
     "density": 1.0,
     "id": "d85576e1-ba3a-4ec7-80d5-c106f780498a",
     "inediblePart": 0,
-    "landOccupation": 5.69807,
+    "landOccupation": 5.69799,
     "name": "Reblochon FR",
     "processId": "56d8db15-7d3b-545a-b105-1d9d3267e077",
     "rawToCookedRatio": 1.0,
@@ -6561,13 +6561,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.3535,
-      "hedges": 0.1667,
-      "plotSize": 0.33476
+      "cropDiversity": 0.35346,
+      "hedges": 0.16668,
+      "plotSize": 0.33472
     },
     "id": "57490ff0-61a0-44cd-bd4f-3a3be7af25f2",
     "inediblePart": 0.1,
-    "landOccupation": 0.382579,
+    "landOccupation": 0.382537,
     "name": "Purée de fruits FR",
     "processId": "f72c93ac-8da3-5140-96bb-7b47e6c3ffee",
     "rawToCookedRatio": 0.856,
@@ -6583,13 +6583,13 @@
     "defaultOrigin": "France",
     "density": 0.447,
     "ecosystemicServices": {
-      "cropDiversity": 0.516,
-      "hedges": 0.24332,
-      "plotSize": 0.48863
+      "cropDiversity": 0.51595,
+      "hedges": 0.2433,
+      "plotSize": 0.48859
     },
     "id": "40a4432b-2b12-45f3-aed2-a8c4e165e15f",
     "inediblePart": 0.1,
-    "landOccupation": 0.558437,
+    "landOccupation": 0.558389,
     "name": "Jus de pomme FR",
     "processId": "45b2eab5-633d-5eb8-8e58-0563ce7c837f",
     "rawToCookedRatio": 1.0,
@@ -6633,7 +6633,7 @@
     },
     "id": "afdc7ea9-6da0-4bab-9821-81acc46e23af",
     "inediblePart": 0,
-    "landOccupation": 0.422115,
+    "landOccupation": 0.422113,
     "name": "Lait de soja par défaut",
     "processId": "5ecdc7a6-67ef-5b65-8cba-282fb1ba2554",
     "rawToCookedRatio": 1.0,
@@ -6655,7 +6655,7 @@
     },
     "id": "fd79d142-7e34-45a4-a0d1-59922b4c8d09",
     "inediblePart": 0,
-    "landOccupation": 1.37966,
+    "landOccupation": 0.041738,
     "name": "Jus de citron UE",
     "processId": "c2fb3abb-266e-5ab0-b393-89a96c0a743a",
     "rawToCookedRatio": 1.0,
@@ -6677,7 +6677,7 @@
     },
     "id": "65e6f518-e5fc-4fda-9af9-287d26e2bbe1",
     "inediblePart": 0,
-    "landOccupation": 0.217924,
+    "landOccupation": 0.217565,
     "name": "Jus de tomate UE",
     "processId": "257e163d-a091-591c-a957-777baa96f57f",
     "rawToCookedRatio": 1.0,
@@ -6694,12 +6694,12 @@
     "density": 0.447,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.07234,
-      "plotSize": 0.75957
+      "hedges": 0.072237,
+      "plotSize": 0.75849
     },
     "id": "c2e4259b-962f-49ea-b7f1-606f81b59207",
     "inediblePart": 0,
-    "landOccupation": 2.02553,
+    "landOccupation": 2.02264,
     "name": "Vinaigre balsamique FR",
     "processId": "6fc98a5b-4193-5883-9d81-5979c73d7b5a",
     "rawToCookedRatio": 1.0,
@@ -6721,7 +6721,7 @@
     },
     "id": "c455b3b8-406b-407a-a525-b2c832522e49",
     "inediblePart": 0.2,
-    "landOccupation": 0.566708,
+    "landOccupation": 0.567091,
     "name": "Abricot par défaut",
     "processId": "035fb863-c652-5caa-acc7-dcf993929b11",
     "rawToCookedRatio": 0.856,
@@ -6737,7 +6737,7 @@
     "density": 1.0,
     "id": "d48015d2-a512-4bac-ba93-82a7ae001b81",
     "inediblePart": 0,
-    "landOccupation": 10.6309,
+    "landOccupation": 10.6433,
     "name": "Viande d'agneau (désossée) UE",
     "processId": "05b3b3c3-e0c0-5df5-9b95-eb67e0625cba",
     "rawToCookedRatio": 0.792,
@@ -6753,7 +6753,7 @@
     "density": 1.0,
     "id": "45e3cd64-1647-4841-bacb-795e2aae4f02",
     "inediblePart": 0,
-    "landOccupation": 7.39752,
+    "landOccupation": 7.40711,
     "name": "Viande d'agneau (désossée) par défaut",
     "processId": "05b3b3c3-e0c0-5df5-9b95-eb67e0625cba",
     "rawToCookedRatio": 0.792,
@@ -6771,11 +6771,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 1.0598,
-      "plotSize": 3.0911
+      "plotSize": 3.091
     },
     "id": "3a0c058b-70db-4fce-9984-e68e2f5a4760",
     "inediblePart": 0.5,
-    "landOccupation": 3.53274,
+    "landOccupation": 3.53262,
     "name": "Amandes en coque FR",
     "processId": "6f2603f2-0d75-5b48-a393-9a401484ba0d",
     "rawToCookedRatio": 1.0,
@@ -6797,7 +6797,7 @@
     },
     "id": "0da203dd-5ce5-42cc-be90-95cc4c49b2ac",
     "inediblePart": 0.5,
-    "landOccupation": 3.53274,
+    "landOccupation": 3.53262,
     "name": "Amandes en coque UE",
     "processId": "6f2603f2-0d75-5b48-a393-9a401484ba0d",
     "rawToCookedRatio": 1.0,
@@ -6819,7 +6819,7 @@
     },
     "id": "99dcb716-b0ab-4ca5-b88a-4de43dbfb1af",
     "inediblePart": 0.5,
-    "landOccupation": 3.53274,
+    "landOccupation": 3.53262,
     "name": "Amandes en coque par défaut",
     "processId": "6f2603f2-0d75-5b48-a393-9a401484ba0d",
     "rawToCookedRatio": 1.0,
@@ -6841,7 +6841,7 @@
     },
     "id": "dd7fe1c9-9d56-4790-b735-3de608a20849",
     "inediblePart": 0.6,
-    "landOccupation": 0.445121,
+    "landOccupation": 0.445095,
     "name": "Artichaut UE",
     "processId": "66065729-d03d-5b6e-9886-61de459fa512",
     "rawToCookedRatio": 0.856,
@@ -6863,7 +6863,7 @@
     },
     "id": "92200507-627e-4ae5-a5f8-cf62ef619b02",
     "inediblePart": 0.6,
-    "landOccupation": 0.445121,
+    "landOccupation": 0.445095,
     "name": "Artichaut par défaut",
     "processId": "66065729-d03d-5b6e-9886-61de459fa512",
     "rawToCookedRatio": 0.856,
@@ -7013,7 +7013,7 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 0.029724,
-      "plotSize": 0.074309
+      "plotSize": 0.07431
     },
     "id": "5461f2bc-7010-41ee-ab90-35312769a49f",
     "inediblePart": 0.2,
@@ -7083,7 +7083,7 @@
     },
     "id": "ea6cc96f-ae22-4f14-ace9-a6a463fd360b",
     "inediblePart": 0.2,
-    "landOccupation": 1.55971,
+    "landOccupation": 1.56147,
     "name": "Cerise UE",
     "processId": "31f47ffb-0ac9-5140-a61e-f41246644d45",
     "rawToCookedRatio": 0.856,
@@ -7100,12 +7100,12 @@
     "density": 0.118,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.12806,
-      "plotSize": 0.32014
+      "hedges": 0.12864,
+      "plotSize": 0.3216
     },
     "id": "d330d763-6baa-442f-b479-55425b1fa54f",
     "inediblePart": 0.1,
-    "landOccupation": 0.51223,
+    "landOccupation": 0.514552,
     "name": "Champignon frais FR",
     "processId": "973dcd67-31ce-5a1c-8db6-152cbc241232",
     "rawToCookedRatio": 0.856,
@@ -7122,12 +7122,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 3.3334,
-      "plotSize": 9.7223
+      "hedges": 3.3328,
+      "plotSize": 9.7206
     },
     "id": "e3a3bd70-1c8e-4b8b-b22f-b1f9958574c8",
     "inediblePart": 0.5,
-    "landOccupation": 11.1112,
+    "landOccupation": 11.1093,
     "name": "Noix avec coque Bio",
     "processId": "9a793483-7dce-5c7a-9e5e-e23ccdadf577",
     "rawToCookedRatio": 1.0,
@@ -7215,7 +7215,7 @@
     },
     "id": "ebb1d5ac-83e9-4295-9067-01e4bc5e43d1",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou chinois UE",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -7237,7 +7237,7 @@
     },
     "id": "3e3f8e66-57c3-43f8-b86c-54fb42af7f45",
     "inediblePart": 0.2,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou chinois par défaut",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -7259,7 +7259,7 @@
     },
     "id": "0896a0d5-b6ae-4b48-9e61-7c7ee42447ec",
     "inediblePart": 0.1,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou de Bruxelles UE",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -7281,7 +7281,7 @@
     },
     "id": "f2ca7ffb-f4b2-478f-8008-41956b2aefa2",
     "inediblePart": 0.1,
-    "landOccupation": 0.461938,
+    "landOccupation": 0.461912,
     "name": "Chou de Bruxelles par défaut",
     "processId": "85933c39-cf0c-5c05-8427-e725ea99276d",
     "rawToCookedRatio": 0.856,
@@ -7303,7 +7303,7 @@
     },
     "id": "45658c32-66d9-4305-a34b-21d6a4cef89c",
     "inediblePart": 0,
-    "landOccupation": 2.15732,
+    "landOccupation": 2.15717,
     "name": "Huile de palme (raffinée) par défaut",
     "processId": "73e684d5-a4c2-5009-8c7e-0dd2e27eed82",
     "rawToCookedRatio": 1.0,
@@ -7325,7 +7325,7 @@
     },
     "id": "ea419fa9-d69f-4735-8fe8-fab427ce5185",
     "inediblePart": 0,
-    "landOccupation": 5.12764,
+    "landOccupation": 5.12758,
     "name": "Huile de tournesol UE",
     "processId": "f6c444b5-2a8f-5a67-8848-9f04dd523408",
     "rawToCookedRatio": 1.0,
@@ -7341,7 +7341,7 @@
     "density": 1.0,
     "id": "dbba1f04-b86c-42aa-96f9-93cfcdf4a141",
     "inediblePart": 0,
-    "landOccupation": 0.537985,
+    "landOccupation": 0.538673,
     "name": "Lait UE",
     "processId": "b7386800-8318-56d3-8f1b-1f802f304a8c",
     "rawToCookedRatio": 1.0,
@@ -7379,7 +7379,7 @@
     },
     "id": "d0cd6516-40b9-40ce-b632-63c3a0ed14c1",
     "inediblePart": 0,
-    "landOccupation": 5.98439,
+    "landOccupation": 5.98476,
     "name": "Lentilles UE",
     "processId": "e45f6ccb-035e-569c-80c5-f8a26993c5b3",
     "rawToCookedRatio": 2.33,
@@ -7401,7 +7401,7 @@
     },
     "id": "c06e8471-88c9-490c-99fc-eb85b4e9e300",
     "inediblePart": 0,
-    "landOccupation": 5.98439,
+    "landOccupation": 5.98476,
     "name": "Lentilles par défaut",
     "processId": "e45f6ccb-035e-569c-80c5-f8a26993c5b3",
     "rawToCookedRatio": 2.33,
@@ -7445,7 +7445,7 @@
     },
     "id": "20c97ec2-4950-4cb6-ac9d-a3a97b63c4ea",
     "inediblePart": 0.5,
-    "landOccupation": 0.237212,
+    "landOccupation": 0.237371,
     "name": "Maïs doux UE",
     "processId": "bb5f2ee6-2b42-5422-b5e6-23f3c3075cee",
     "rawToCookedRatio": 2.259,
@@ -7467,7 +7467,7 @@
     },
     "id": "c723eb89-a64f-405d-bb6b-6dced54c46ba",
     "inediblePart": 0.5,
-    "landOccupation": 2.124,
+    "landOccupation": 2.12399,
     "name": "Autres céréales et produits céréaliers (non encore répertoriés)",
     "processId": "6d737375-f7f8-5d68-aed5-df00b19e90f7",
     "rawToCookedRatio": 1.0,
@@ -7483,7 +7483,7 @@
     "density": 1.0,
     "id": "f30016f7-2e54-45ee-96e8-cd0140872ce6",
     "inediblePart": 0,
-    "landOccupation": 9.16768,
+    "landOccupation": 9.17058,
     "name": "Autres produits laitiers (non encore répertoriés)",
     "processId": "7e0e3538-e229-556b-b5ce-b69cfa9e1880",
     "rawToCookedRatio": 1.0,
@@ -7504,7 +7504,7 @@
     },
     "id": "748b0518-02cd-4e7c-8829-78e527e92298",
     "inediblePart": 0.2,
-    "landOccupation": 0.531675,
+    "landOccupation": 0.531658,
     "name": "Autres fruits, légumes, légumineuses, oléagineux (non encore répertoriés)",
     "processId": "c6598f48-29cb-5b7c-9add-d58080fbd04c",
     "rawToCookedRatio": 0.856,
@@ -7520,7 +7520,7 @@
     "density": 1.0,
     "id": "7f6bd70c-1385-4855-9c25-e9a34e91df74",
     "inediblePart": 0,
-    "landOccupation": 43.416,
+    "landOccupation": 43.4211,
     "name": "Autres viandes, oeufs, poissons (non encore répertoriés)",
     "processId": "48efc88e-dff7-55f0-a1b3-540d17fde967",
     "rawToCookedRatio": 0.792,
@@ -7536,13 +7536,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 7.7534,
-      "hedges": 3.6561,
-      "plotSize": 7.3422
+      "cropDiversity": 7.7622,
+      "hedges": 3.6603,
+      "plotSize": 7.3505
     },
     "id": "3211b18f-83b2-4cf8-a0fd-42962f70b8b4",
     "inediblePart": 0,
-    "landOccupation": 8.39111,
+    "landOccupation": 8.40062,
     "name": "Autres ingrédients divers (non encore répertoriés)",
     "processId": "74cf4852-dbbf-5a4c-b82c-735721092903",
     "rawToCookedRatio": 1.0,
@@ -7558,7 +7558,7 @@
     "density": 1.0,
     "id": "1bd78657-5169-4a53-aadd-881aedc7d3e7",
     "inediblePart": 0,
-    "landOccupation": 2.10364e-5,
+    "landOccupation": 2.22964e-5,
     "name": "Autres eaux et autres boissons (non encore répertoriées)",
     "processId": "d3fc19a4-7ace-5870-aeb3-fe35a8189d94",
     "rawToCookedRatio": 1.0,
@@ -7573,7 +7573,7 @@
     "density": 1.0,
     "id": "fda34c66-9093-458c-b7df-a091730b6b64",
     "inediblePart": 0,
-    "landOccupation": 9.35109,
+    "landOccupation": 9.42511,
     "name": "Autres viandes blanches, oeufs et poisson (non encore répertoriés)",
     "processId": "af9d1017-051e-557a-99fd-8012b8ff9f83",
     "rawToCookedRatio": 0.755,
@@ -7589,7 +7589,7 @@
     "density": 1.0,
     "id": "168b4b21-5fa8-484b-a192-83e7dda8f133",
     "inediblePart": 0.2,
-    "landOccupation": 1.85501,
+    "landOccupation": 1.85786,
     "name": "Autres produits issus de la pêche (non encore répertoriés)",
     "processId": "f0c417b7-0ca4-5260-a43d-27f5ee572e43",
     "rawToCookedRatio": 0.819,
@@ -7626,13 +7626,13 @@
     "defaultOrigin": "EuropeAndMaghreb",
     "density": 1.0,
     "ecosystemicServices": {
-      "cropDiversity": 3.4612,
-      "hedges": 2.4539,
-      "plotSize": 3.2207
+      "cropDiversity": 3.4636,
+      "hedges": 2.4556,
+      "plotSize": 3.223
     },
     "id": "66e7706b-5129-410c-b070-0a7feff2680f",
     "inediblePart": 0,
-    "landOccupation": 8.58862,
+    "landOccupation": 8.59466,
     "name": "Autres huiles (non encore répertoriées)",
     "processId": "c7984a1c-66cb-52ea-bb54-763e0da8ecad",
     "rawToCookedRatio": 1.0,
@@ -7728,7 +7728,7 @@
     "density": 1.0,
     "id": "79ce12b6-db5c-43c8-be48-44deb8f704e1",
     "inediblePart": 0.2,
-    "landOccupation": 0.00403671,
+    "landOccupation": 0.0162783,
     "name": "Sardine par défaut",
     "processId": "341bcac7-3807-5ed0-8f2f-53e4ba863282",
     "rawToCookedRatio": 1.0,
@@ -7760,7 +7760,7 @@
     "density": 1.0,
     "id": "6875d374-d24e-45d1-93c1-39aa52e3713c",
     "inediblePart": 0.5,
-    "landOccupation": 0.328836,
+    "landOccupation": 0.106188,
     "name": "Crabe FR",
     "processId": "741ddf36-8294-5997-9611-e8cfed46dfaa",
     "rawToCookedRatio": 0.819,
@@ -7776,7 +7776,7 @@
     "density": 1.0,
     "id": "4f075683-12a5-423b-bd78-75aed2781290",
     "inediblePart": 0.5,
-    "landOccupation": 0.62051,
+    "landOccupation": 0.224472,
     "name": "Crabe UE",
     "processId": "84182cec-81b4-5fa3-bcf1-6d085774bb77",
     "rawToCookedRatio": 0.819,
@@ -7808,7 +7808,7 @@
     "density": 1.0,
     "id": "5b0f85b9-5bc9-4eca-b134-af3a344f586e",
     "inediblePart": 0.5,
-    "landOccupation": 1.83983,
+    "landOccupation": 0.576489,
     "name": "Homard FR",
     "processId": "5a8697e7-ad87-52de-8c80-43924ff457e5",
     "rawToCookedRatio": 0.819,
@@ -7824,7 +7824,7 @@
     "density": 1.0,
     "id": "16ff0416-9d7f-4e3b-9e2e-7a25e729b863",
     "inediblePart": 0.5,
-    "landOccupation": 1.83215,
+    "landOccupation": 0.600389,
     "name": "Homard UE",
     "processId": "589f255b-e2d9-525d-b9aa-6e35f9111d70",
     "rawToCookedRatio": 0.819,
@@ -7840,7 +7840,7 @@
     "density": 1.0,
     "id": "c217f7ad-7413-4663-b049-1ce6c040f597",
     "inediblePart": 0.5,
-    "landOccupation": 0.125442,
+    "landOccupation": 0.0672524,
     "name": "Homard par défaut",
     "processId": "04037b75-7d5f-5fa3-9498-ace56417f706",
     "rawToCookedRatio": 0.819,
@@ -7856,7 +7856,7 @@
     "density": 1.0,
     "id": "cacf491b-5529-4e0c-af3f-75ab1d007655",
     "inediblePart": 0.2,
-    "landOccupation": 629.095,
+    "landOccupation": 5.14488,
     "name": "Saumon cru UE",
     "processId": "b5a50474-8d15-55c1-b9f6-fe9e134ec019",
     "rawToCookedRatio": 1.0,
@@ -7894,7 +7894,7 @@
     },
     "id": "6467c956-277d-4e09-80c2-b0b062f84086",
     "inediblePart": 0.2,
-    "landOccupation": 1.2835,
+    "landOccupation": 1.28386,
     "name": "Mandarine par défaut",
     "processId": "205fbb70-754d-5160-98aa-736cf6231c22",
     "rawToCookedRatio": 0.856,
@@ -7916,7 +7916,7 @@
     },
     "id": "7b30c4ad-e851-4274-8062-4e14850108a9",
     "inediblePart": 0.4,
-    "landOccupation": 0.0766257,
+    "landOccupation": 0.424457,
     "name": "Melon par défaut",
     "processId": "dbf9fb3d-a447-571b-bcb3-48b92f1df68d",
     "rawToCookedRatio": 0.856,
@@ -7938,7 +7938,7 @@
     },
     "id": "869f04ba-6780-4124-9240-b7be514be1ba",
     "inediblePart": 0.03,
-    "landOccupation": 3.45,
+    "landOccupation": 3.45114,
     "name": "Myrtille UE",
     "processId": "e2685c22-5b8b-57b9-b112-590de9ce9b7f",
     "rawToCookedRatio": 0.856,
@@ -7960,7 +7960,7 @@
     },
     "id": "0eb658ae-a7e4-4b74-a7eb-9604b23c2f98",
     "inediblePart": 0.03,
-    "landOccupation": 3.45,
+    "landOccupation": 3.45114,
     "name": "Myrtille FR",
     "processId": "e2685c22-5b8b-57b9-b112-590de9ce9b7f",
     "rawToCookedRatio": 0.856,
@@ -7977,12 +7977,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 3.8359,
-      "plotSize": 11.188
+      "hedges": 3.8341,
+      "plotSize": 11.183
     },
     "id": "df64fdd7-1900-402c-86b9-e766e22c27ed",
     "inediblePart": 0.5,
-    "landOccupation": 12.7862,
+    "landOccupation": 12.7804,
     "name": "Noisette avec coque Bio",
     "processId": "6e3b1b19-b91b-55aa-bd62-6bef269d3411",
     "rawToCookedRatio": 1.0,
@@ -7999,12 +7999,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 8.2358,
-      "plotSize": 24.021
+      "hedges": 8.2333,
+      "plotSize": 24.014
     },
     "id": "4531bf0a-7910-4166-b3b1-e94027a10426",
     "inediblePart": 0.5,
-    "landOccupation": 27.4528,
+    "landOccupation": 27.4443,
     "name": "Noisette décortiquée Bio",
     "processId": "d024fd06-4e3f-5a50-a1ec-2d5e744117c8",
     "rawToCookedRatio": 1.0,
@@ -8021,12 +8021,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 4.7392,
-      "plotSize": 13.823
+      "hedges": 4.7391,
+      "plotSize": 13.822
     },
     "id": "60184de2-cc9e-4618-924a-b8fecf080c8b",
     "inediblePart": 0.5,
-    "landOccupation": 15.7975,
+    "landOccupation": 15.797,
     "name": "Noisette décortiquée FR",
     "processId": "9109ede7-b2f6-594b-9125-e2082ce2c0f1",
     "rawToCookedRatio": 1.0,
@@ -8043,12 +8043,12 @@
     "density": 0.24,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 3.8651,
-      "plotSize": 11.273
+      "hedges": 3.8645,
+      "plotSize": 11.271
     },
     "id": "17b171b8-1e5e-472f-a6c5-8053b5ae4c9a",
     "inediblePart": 0.5,
-    "landOccupation": 12.8837,
+    "landOccupation": 12.8815,
     "name": "Châtaigne avec coque Bio",
     "processId": "5c14a077-1794-591a-a7c3-eeee0aea3569",
     "rawToCookedRatio": 1.0,
@@ -8070,7 +8070,7 @@
     },
     "id": "0060abe9-a6c2-47fb-bc87-404a9bbd3971",
     "inediblePart": 0.5,
-    "landOccupation": 6.53,
+    "landOccupation": 1.62257,
     "name": "Noix avec coque UE",
     "processId": "9d2a146b-8560-57a1-bf8d-98b59f2f02db",
     "rawToCookedRatio": 1.0,
@@ -8092,7 +8092,7 @@
     },
     "id": "69d6cbd1-914d-40ea-aaa1-082911ed2fdd",
     "inediblePart": 0.5,
-    "landOccupation": 6.53,
+    "landOccupation": 1.62257,
     "name": "Noix avec coque par défaut",
     "processId": "9d2a146b-8560-57a1-bf8d-98b59f2f02db",
     "rawToCookedRatio": 1.0,
@@ -8114,7 +8114,7 @@
     },
     "id": "34a88056-cd23-40e6-8eaa-6a64595fa9b2",
     "inediblePart": 0,
-    "landOccupation": 1.35883,
+    "landOccupation": 1.35913,
     "name": "Orge UE",
     "processId": "32e2ea09-f2de-5552-837b-5a5157064caa",
     "rawToCookedRatio": 2.259,
@@ -8154,11 +8154,11 @@
     "ecosystemicServices": {
       "cropDiversity": 0,
       "hedges": 1.6852,
-      "plotSize": 4.9151
+      "plotSize": 4.915
     },
     "id": "115a010d-270f-43f8-9827-b27348a08d13",
     "inediblePart": 0.5,
-    "landOccupation": 5.61721,
+    "landOccupation": 5.61718,
     "name": "Pistache avec coque Bio",
     "processId": "5244d4d6-7f6a-5b09-aa80-c93a705ebb1a",
     "rawToCookedRatio": 1.0,
@@ -8180,7 +8180,7 @@
     },
     "id": "7aea09f0-f3ae-4df0-9cbc-ba4007ce1459",
     "inediblePart": 0.2,
-    "landOccupation": 0.174722,
+    "landOccupation": 0.174645,
     "name": "Poireau UE",
     "processId": "5fb3671b-4461-5f97-8577-6e6b4c8d044f",
     "rawToCookedRatio": 0.856,
@@ -8202,7 +8202,7 @@
     },
     "id": "bb58047c-2b1d-42ad-b5a2-bc5ebf8289a1",
     "inediblePart": 0.2,
-    "landOccupation": 0.174722,
+    "landOccupation": 0.174645,
     "name": "Poireau par défaut",
     "processId": "5fb3671b-4461-5f97-8577-6e6b4c8d044f",
     "rawToCookedRatio": 0.856,
@@ -8219,12 +8219,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 3.6477,
-      "plotSize": 5.148
+      "hedges": 1.3505,
+      "plotSize": 1.9059
     },
     "id": "134bc97e-e3dc-44de-8ec6-947b608a2d42",
     "inediblePart": 0,
-    "landOccupation": 8.2368,
+    "landOccupation": 3.04951,
     "name": "Pois par défaut",
     "processId": "b1de3c75-d408-5099-b3f6-8de91704766d",
     "rawToCookedRatio": 2.259,
@@ -8246,7 +8246,7 @@
     },
     "id": "0fdccf80-b169-4b34-8409-d15c0d100957",
     "inediblePart": 0,
-    "landOccupation": 8.2368,
+    "landOccupation": 2.63969,
     "name": "Pois UE",
     "processId": "90f96aaa-159f-50a4-8456-55bad07c4cc4",
     "rawToCookedRatio": 2.259,
@@ -8268,7 +8268,7 @@
     },
     "id": "bfdf1505-8426-499e-8286-a1e4b4920c7e",
     "inediblePart": 0,
-    "landOccupation": 2.34737,
+    "landOccupation": 2.34733,
     "name": "Pois FR",
     "processId": "dc856fdb-f22f-5ccc-969e-de539aec81ac",
     "rawToCookedRatio": 2.259,
@@ -8290,7 +8290,7 @@
     },
     "id": "227914fd-5cf5-4c05-958f-ac4321e6c557",
     "inediblePart": 0.2,
-    "landOccupation": 1.23981,
+    "landOccupation": 1.24093,
     "name": "Pois chiche par défaut",
     "processId": "4f4050d3-9afe-5a90-b1ff-7505465f0a31",
     "rawToCookedRatio": 2.33,
@@ -8307,12 +8307,12 @@
     "density": 0.295,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.020184,
-      "plotSize": 0.05046
+      "hedges": 0.021327,
+      "plotSize": 0.053318
     },
     "id": "361139ac-1028-4cc8-9c0e-4955c5fa39d3",
     "inediblePart": 0.03,
-    "landOccupation": 0.0807367,
+    "landOccupation": 0.0853083,
     "name": "Poivron sous serre non chauffée FR",
     "processId": "74a8638a-7e28-5023-85d8-8bdd83ce70d6",
     "rawToCookedRatio": 0.856,
@@ -8334,7 +8334,7 @@
     },
     "id": "123d51c5-27a3-4b57-a1d2-3b627dc4032a",
     "inediblePart": 0.03,
-    "landOccupation": 0.0807367,
+    "landOccupation": 0.0853083,
     "name": "Poivron sous serre non chauffée UE",
     "processId": "74a8638a-7e28-5023-85d8-8bdd83ce70d6",
     "rawToCookedRatio": 0.856,
@@ -8356,7 +8356,7 @@
     },
     "id": "d018ec1f-d3c8-4fa1-a70d-bca1b0380c47",
     "inediblePart": 0.03,
-    "landOccupation": 0.0807367,
+    "landOccupation": 0.0853083,
     "name": "Poivron sous serre non chauffée par défaut",
     "processId": "74a8638a-7e28-5023-85d8-8bdd83ce70d6",
     "rawToCookedRatio": 0.856,
@@ -8378,7 +8378,7 @@
     },
     "id": "8c2299d6-49e4-493c-bafe-c0b4b7ef2079",
     "inediblePart": 0.1,
-    "landOccupation": 0.78076,
+    "landOccupation": 0.78111,
     "name": "Pomme par défaut",
     "processId": "75a76ed9-ad03-5269-a6f5-0fb86ce1073f",
     "rawToCookedRatio": 0.856,
@@ -8400,7 +8400,7 @@
     },
     "id": "9bdb3037-1154-4477-a99c-6ca4ba9c9168",
     "inediblePart": 0.1,
-    "landOccupation": 0.24724,
+    "landOccupation": 0.247386,
     "name": "Pomme de terre de table UE",
     "processId": "22dbe2d5-b300-5ccb-be44-88aa86c9c545",
     "rawToCookedRatio": 0.856,
@@ -8422,7 +8422,7 @@
     },
     "id": "33c427df-1967-452a-91b0-cdc1a2c9ca04",
     "inediblePart": 0.1,
-    "landOccupation": 0.620121,
+    "landOccupation": 0.620426,
     "name": "Pomme de terre de table par défaut",
     "processId": "22dbe2d5-b300-5ccb-be44-88aa86c9c545",
     "rawToCookedRatio": 0.856,
@@ -8438,7 +8438,7 @@
     "density": 1.0,
     "id": "e57ae0e0-6277-427f-9090-087c97008966",
     "inediblePart": 0,
-    "landOccupation": 6.89045,
+    "landOccupation": 9.06905,
     "name": "Blanc de poulet cru UE",
     "processId": "311355dc-d317-565e-8496-48f248fd1b58",
     "rawToCookedRatio": 0.755,
@@ -8455,12 +8455,12 @@
     "density": 1.0,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.016926,
-      "plotSize": 0.042315
+      "hedges": 0.016922,
+      "plotSize": 0.042304
     },
     "id": "ffd854c7-858b-4b97-9827-f99d2b71d48d",
     "inediblePart": 0,
-    "landOccupation": 0.0677044,
+    "landOccupation": 0.0676861,
     "name": "Purée de tomates FR",
     "processId": "345cb680-a630-54c5-96d1-2e83a11753da",
     "rawToCookedRatio": 1.0,
@@ -8592,7 +8592,7 @@
     },
     "id": "07433a1e-66d9-45c2-889b-38afb54622de",
     "inediblePart": 0.2,
-    "landOccupation": 1.49183,
+    "landOccupation": 1.56147,
     "name": "Prune UE",
     "processId": "31f47ffb-0ac9-5140-a61e-f41246644d45",
     "rawToCookedRatio": 0.856,
@@ -8614,7 +8614,7 @@
     },
     "id": "b83a6d8e-5afa-447b-be7b-5df9573e7d3b",
     "inediblePart": 0.2,
-    "landOccupation": 1.25571,
+    "landOccupation": 1.56147,
     "name": "Prune par défaut",
     "processId": "31f47ffb-0ac9-5140-a61e-f41246644d45",
     "rawToCookedRatio": 0.856,
@@ -8653,12 +8653,12 @@
     "density": 0.6195,
     "ecosystemicServices": {
       "cropDiversity": 0,
-      "hedges": 0.62787,
-      "plotSize": 1.5697
+      "hedges": 0.6315,
+      "plotSize": 1.5788
     },
     "id": "0a2edda7-2158-4206-8d8c-2151fc925215",
     "inediblePart": 0,
-    "landOccupation": 2.51149,
+    "landOccupation": 2.526,
     "name": "Oignons déshydratés par défaut",
     "processId": "d87062b2-a9af-52c3-8ba9-554c929f5c8a",
     "rawToCookedRatio": 1.0,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -710,7 +709,7 @@ dev = [
 requires-dist = [
     { name = "bw2analyzer", specifier = "==0.11.7" },
     { name = "bw2calc", specifier = "==2.0.1" },
-    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
+    { name = "bw2data", git = "https://github.com/vjousse/brightway2-data?rev=1aa5d0a048b6ec46484c1fe8e50a94650760f869#1aa5d0a048b6ec46484c1fe8e50a94650760f869" },
     { name = "bw2io", extras = ["multifunctional"], specifier = "==0.9.5" },
     { name = "bw2parameters", specifier = "==1.1.0" },
     { name = "deadcode", specifier = ">=2.4.1" },


### PR DESCRIPTION
## :wrench: Problem

landOccupation is wrong in a number of cases. Being harcoded in `activities.json` they end up being wrong longer than they should.

## :cake: Solution

- remove `landOccupation` from `activities.json` to force recomputation.
- hardcoded those that were wrong by checking in simapro.

## :desert_island: How to test

- Check that landOccupation is recomputed.
- Check that those which are very different seem ok (either by intuition :-) or by checking in simapro, or by comparing with other similar products.