### PR TITLE
chore: ignore the .vscode settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ activities.*.json
 *.ipynb
 graphs/
 __pycache__/
+.vscode/


### PR DESCRIPTION
## :wrench: Problem

The .vscode folder should not be versioned.

## :cake: Solution

Add the folder path to the .gitignore file.
NB: it’s already the case in the `ecobalyse` repo.