### PR TITLE
chore: the CI should run the linting tasks, but not all the pre-commit ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
           version: "latest"
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pre-commit
-        run: uv run pre-commit run --all-files
+      - name: Lint the project
+        run: npm run lint:all
 
       - name: Check JSON db formating
         run: npm run db:validate


### PR DESCRIPTION
## :wrench: Problem

Since a [recent fix](https://github.com/MTES-MCT/ecobalyse-data/pull/148/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R10) to the pre-commit.yaml file, the CI was failing when merging a PR, as the pre-commit prevent merging into the `main` branch.

## :cake: Solution

The CI should not run all of the pre-commit tasks, but only the linting.