### PR TITLE
fix: exclude PEF from open data exports

### DIFF
--- a/bin/export_datagouv.py
+++ b/bin/export_datagouv.py
@@ -40,7 +40,6 @@ def rearrange_keys(process: dict) -> dict:
         "waste": process["waste"],
         "source": process["source"],
         "ecs": process["impacts"]["ecs"],
-        "pef": process["impacts"]["pef"],
     }
 
 


### PR DESCRIPTION
## :wrench: Problem

The PEF score should not be published in the open-data files.
