### PR TITLE
fix: revert the exclusion of PEF from open data exports

### DIFF
--- a/bin/export_datagouv.py
+++ b/bin/export_datagouv.py
@@ -40,6 +40,7 @@ def rearrange_keys(process: dict) -> dict:
         "waste": process["waste"],
         "source": process["source"],
         "ecs": process["impacts"]["ecs"],
+        "pef": process["impacts"]["pef"],
     }
 
 


### PR DESCRIPTION
Reverts MTES-MCT/ecobalyse-data#163