### PR TITLE
chore: correct custom source

### DIFF
--- a/activities.json
+++ b/activities.json
@@ -1263,7 +1263,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -1303,7 +1303,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -1343,7 +1343,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -1435,7 +1435,7 @@
     "categories": [
       "transport"
     ],
-    "comment": "Ancien identifiant (12/2024): f49b27fa-f22e-c6e1-ab4b-e9f873e2e648.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): f49b27fa-f22e-c6e1-ab4b-e9f873e2e648.",
     "density": 0,
     "displayName": "Transport en camion non spécifié France",
     "elecMJ": 0,
@@ -1465,7 +1465,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -2089,7 +2089,7 @@
     "categories": [
       "transport"
     ],
-    "comment": "Ancien identifiant (12/2024): 1ead35dd-fc71-4b0c-9410-7e39da95c7dc.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 1ead35dd-fc71-4b0c-9410-7e39da95c7dc.",
     "density": 0,
     "displayName": "Transport en voiture jusqu'au point de collecte précalculé pour la fin de vie",
     "elecMJ": 0,
@@ -2119,7 +2119,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "Item(s)",
     "waste": 0
   },
@@ -2246,7 +2246,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 49adf2a8-c74f-46af-b4c7-e1a8e1f5a6cb.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 49adf2a8-c74f-46af-b4c7-e1a8e1f5a6cb.",
     "density": 0,
     "displayName": "Délavage chimique, procédé majorant, traitement inefficace des eaux usées",
     "elecMJ": 6.53,
@@ -2276,7 +2276,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -2286,7 +2286,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 710987ca-f483-4f1c-9122-38b620f4062b.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 710987ca-f483-4f1c-9122-38b620f4062b.",
     "density": 0,
     "displayName": "Impression pigmentaire, procédé représentatif, traitement moyen des eaux usées",
     "elecMJ": 4.56,
@@ -2316,7 +2316,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "m2",
     "waste": 0
   },
@@ -2326,7 +2326,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 0810b8e5-a3d9-4607-bccc-83d112573260.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 0810b8e5-a3d9-4607-bccc-83d112573260.",
     "density": 0,
     "displayName": "Impression fixé-lavé, procédé représentatif, traitement moyen des eaux usées",
     "elecMJ": 5.22,
@@ -2356,7 +2356,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "m2",
     "waste": 0
   },

--- a/public/data/processes.json
+++ b/public/data/processes.json
@@ -3095,7 +3095,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 49adf2a8-c74f-46af-b4c7-e1a8e1f5a6cb.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 49adf2a8-c74f-46af-b4c7-e1a8e1f5a6cb.",
     "density": 0,
     "displayName": "Délavage chimique, procédé majorant, traitement inefficace des eaux usées",
     "elecMJ": 6.53,
@@ -3128,7 +3128,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -3940,7 +3940,7 @@
     "categories": [
       "transport"
     ],
-    "comment": "Ancien identifiant (12/2024): 1ead35dd-fc71-4b0c-9410-7e39da95c7dc.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 1ead35dd-fc71-4b0c-9410-7e39da95c7dc.",
     "density": 0,
     "displayName": "Transport en voiture jusqu'au point de collecte précalculé pour la fin de vie",
     "elecMJ": 0,
@@ -3973,7 +3973,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "Item(s)",
     "waste": 0
   },
@@ -5424,7 +5424,7 @@
     "categories": [
       "transport"
     ],
-    "comment": "Ancien identifiant (12/2024): f49b27fa-f22e-c6e1-ab4b-e9f873e2e648.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): f49b27fa-f22e-c6e1-ab4b-e9f873e2e648.",
     "density": 0,
     "displayName": "Transport en camion non spécifié France",
     "elecMJ": 0,
@@ -5457,7 +5457,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -7535,7 +7535,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 0810b8e5-a3d9-4607-bccc-83d112573260.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 0810b8e5-a3d9-4607-bccc-83d112573260.",
     "density": 0,
     "displayName": "Impression fixé-lavé, procédé représentatif, traitement moyen des eaux usées",
     "elecMJ": 5.22,
@@ -7568,7 +7568,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "m2",
     "waste": 0
   },
@@ -10586,7 +10586,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -12678,7 +12678,7 @@
     "categories": [
       "transformation"
     ],
-    "comment": "Ancien identifiant (12/2024): 710987ca-f483-4f1c-9122-38b620f4062b.",
+    "comment": "Données provenant de Base Impacts 2.01. Ancien identifiant (12/2024): 710987ca-f483-4f1c-9122-38b620f4062b.",
     "density": 0,
     "displayName": "Impression pigmentaire, procédé représentatif, traitement moyen des eaux usées",
     "elecMJ": 4.56,
@@ -12711,7 +12711,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Base Impacts 2.01",
+    "source": "Custom",
     "unit": "m2",
     "waste": 0
   },
@@ -15804,7 +15804,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },
@@ -16945,7 +16945,7 @@
     "scopes": [
       "textile"
     ],
-    "source": "Ecobalyse",
+    "source": "Custom",
     "unit": "kg",
     "waste": 0
   },

--- a/tests/test_json_consistency.py
+++ b/tests/test_json_consistency.py
@@ -20,22 +20,39 @@ def duplicate(filename, content, key):
         raise AssertionError(f"Duplicate {key} in {filename}: " + ", ".join(duplicates))
 
 
-def consistent_metadata(filename, content):
+def metadata_consistency(filename, activities):
     """
     Check that metadata and scope are consistent in activities.json
     - an activity can have a scope and no metadata for that scope (metadata is optional)
     - but an activity can't have metadata for scopeA and not have scopeA in activity["scopes"]
     """
-    for object in content:
-        metadata = object.get("metadata")
+    for activity in activities:
+        metadata = activity.get("metadata")
         if metadata:
             metadata_keys = set(metadata.keys())
-            scopes = set(object["scopes"])
+            scopes = set(activity["scopes"])
             if not metadata_keys <= scopes:  # metadata_keys must be a subset of scopes
                 extra_metadata = metadata_keys - scopes
                 raise AssertionError(
-                    f"Inconsistent metadata-scopes for object {object['displayName']} in {filename}: metadata keys {extra_metadata} not in scopes {scopes}"
+                    f"Inconsistent metadata-scopes for object {activity['displayName']} in {filename}: metadata keys {extra_metadata} not in scopes {scopes}"
                 )
+
+
+def custom_source_consistency(filename, activities):
+    """
+    Check that source = "Custom" if and only if impacts are present
+    """
+    for activity in activities:
+        source = activity["source"]
+        display_name = activity["displayName"]
+        if "impacts" in activity and source != "Custom":
+            raise AssertionError(
+                f"Custom source inconsistency : activity {display_name} has hardcoded impacts but source is not 'Custom' (source = {source})"
+            )
+        elif "impacts" not in activity and source == "Custom":
+            raise AssertionError(
+                f"Custom source inconsistency : activity {display_name} has source = 'Custom' but no hardcoded impacts"
+            )
 
 
 def invalid_uuid(filename, content, key):
@@ -179,7 +196,7 @@ CHECKS = {
 
 # Content-level checks: validate relationships across the entire content
 CONTENT_CHECKS = {
-    "activities.json": (consistent_metadata,),
+    "activities.json": (metadata_consistency, custom_source_consistency),
 }
 
 


### PR DESCRIPTION
## :wrench: Problem

A few textile processes have a wrong source field : Ecobalyse (used for constructed processes) instead of Custom (used for hardcoded)

https://github.com/MTES-MCT/ecobalyse-data/issues/175


## :cake: Solution

- implementing @ccomb's fix of textile sources : https://github.com/MTES-MCT/ecobalyse-data/pull/153
- correcting also Base Impacts sources
- adding a test to ensure custom source consistency

## :desert_island: How to test

npm run export:all should create no diff