### PR TITLE
chore: make the paths of the data used in tests more explicit

### DIFF
--- a/bin/export.py
+++ b/bin/export.py
@@ -4,7 +4,6 @@ import json
 import logging
 import multiprocessing
 from enum import Enum
-from os.path import dirname, join
 from pathlib import Path
 from typing import List, Optional
 
@@ -12,7 +11,7 @@ import typer
 from bw2data.project import projects
 from typing_extensions import Annotated
 
-from config import get_absolute_path, settings
+from config import PROJECT_ROOT_DIR, settings
 from ecobalyse_data.export import export_generic
 from ecobalyse_data.export import food as export_food
 from ecobalyse_data.export import process as export_process
@@ -21,9 +20,6 @@ from ecobalyse_data.logging import logger
 from models.process import GENERIC_SCOPES, Scope
 
 app = typer.Typer(pretty_exceptions_show_locals=False)
-
-
-PROJECT_ROOT_DIR = dirname(dirname(__file__))
 
 
 class MetadataScope(str, Enum):
@@ -45,6 +41,7 @@ def metadata(
             help="The number of CPUs/cores to use for computation. Default to MAX/2."
         ),
     ] = max(multiprocessing.cpu_count() // 2, 1),
+    root_dir: Path = PROJECT_ROOT_DIR,
 ):
     """
     Export metadata files (materials.json, ingredients.json, …)
@@ -55,9 +52,9 @@ def metadata(
     dirs_to_export_to = [settings.output_dir]
 
     if settings.LOCAL_EXPORT:
-        dirs_to_export_to.append(join(get_absolute_path("."), "public", "data"))
+        dirs_to_export_to.append(root_dir / "public" / "data")
 
-    activities_path = get_absolute_path("activities.json")
+    activities_path = root_dir / "activities.json"
     logger.debug(f"-> Loading activities file {activities_path}")
 
     with open(activities_path, "r") as file:
@@ -77,7 +74,7 @@ def metadata(
             export_textile.activities_to_materials_json(
                 activities_textile_materials,
                 materials_paths=[
-                    join(get_absolute_path(dir), scope_dirname, "materials.json")
+                    root_dir / dir / scope_dirname / "materials.json"
                     for dir in dirs_to_export_to
                 ],
             )
@@ -90,22 +87,21 @@ def metadata(
                 if scope_dirname in a.get("scopes", [])
                 and "ingredient" in a.get("categories", [])
             ]
-            es_files_path = get_absolute_path(
-                scope_dirname,
-                base_path=join(PROJECT_ROOT_DIR, settings.get("BASE_PATH", "")),
-            )
+            es_files_path = root_dir / scope_dirname
             ingredients_paths = [
-                join(get_absolute_path(dir), scope_dirname, "ingredients.json")
+                root_dir / dir / scope_dirname / "ingredients.json"
                 for dir in dirs_to_export_to
             ]
-            ecosystemic_factors_path = join(
-                es_files_path, settings.scopes.food.ecosystemic_factors_file
+            ecosystemic_factors_path = (
+                es_files_path / settings.scopes.food.ecosystemic_factors_file
             )
-            feed_file_path = join(es_files_path, settings.scopes.food.feed_file)
-            animal_to_meat_file_path = join(
-                es_files_path, settings.scopes.food.animal_to_meat_file
+
+            feed_file_path = es_files_path / settings.scopes.food.feed_file
+            animal_to_meat_file_path = (
+                es_files_path / settings.scopes.food.animal_to_meat_file
             )
-            ugb_file_path = join(es_files_path, settings.scopes.food.ugb_file)
+
+            ugb_file_path = es_files_path / settings.scopes.food.ugb_file
 
             export_food.activities_to_ingredients_json(
                 activities_food_ingredients,
@@ -127,17 +123,15 @@ def metadata(
 
             export_generic.activities_to_processes_generic_json(
                 generic_activities,
-                processes_impacts_path=join(
-                    # last dir is local dir
-                    get_absolute_path(dirs_to_export_to[-1]),
-                    settings.processes_impacts_full_file,
-                ),
+                processes_impacts_path=root_dir
+                / dirs_to_export_to[-1]  # last dir is local dir
+                / settings.processes_impacts_full_file,
                 aggregated_output_paths=[
-                    join(get_absolute_path(dir), "processes_generic.json")
+                    root_dir / dir / "processes_generic.json"
                     for dir in dirs_to_export_to
                 ],
                 impacts_output_paths=[
-                    join(get_absolute_path(dir), "processes_generic_impacts.json")
+                    root_dir / dir / "processes_generic_impacts.json"
                     for dir in dirs_to_export_to
                 ],
                 cpu_count=cpu_count,
@@ -153,7 +147,7 @@ def processes(
     graph_folder: Annotated[
         Optional[Path],
         typer.Option(help="The graph output path."),
-    ] = join(get_absolute_path("."), "graphs"),
+    ] = PROJECT_ROOT_DIR / "graphs",
     display_changes: Annotated[
         bool,
         typer.Option(help="Display changes with old processes."),
@@ -173,6 +167,7 @@ def processes(
     plot: bool = typer.Option(False, "--plot", "-p"),
     merge: bool = typer.Option(False, "--merge", "-m"),
     verbose: bool = typer.Option(False, "--verbose", "-v"),
+    root_dir: Path = PROJECT_ROOT_DIR,
 ):
     """
     Export processes. If scope is specified, only exports processes for that scope.
@@ -188,9 +183,9 @@ def processes(
         should_plot = True
 
     if settings.local_export:
-        dirs_to_export_to.append(join(get_absolute_path("."), "public", "data"))
+        dirs_to_export_to.append(root_dir / "public" / "data")
 
-    activities_path = get_absolute_path("activities.json")
+    activities_path = root_dir / "activities.json"
     logger.debug(f"-> Loading activities file {activities_path}")
 
     with open(activities_path, "r") as file:

--- a/bin/export_bw_db.py
+++ b/bin/export_bw_db.py
@@ -37,7 +37,7 @@ def main(
     db = bw2data.Database(db_name)
 
     # Specify data paths
-    data_dir = os.path.join(PROJECT_ROOT_DIR, "ecobalyse_data", "data")
+    data_dir = PROJECT_ROOT_DIR / "ecobalyse_data" / "data"
 
     filepath_simapro_units = os.path.join(data_dir, "simapro_units.yml")
     filepath_simapro_compartments = os.path.join(data_dir, "simapro_compartments.yml")
@@ -47,9 +47,9 @@ def main(
         "3.10": os.path.join(data_dir, "flows_biosphere_310.csv"),
     }
 
-    simapro_biosphere_path = os.path.join(PROJECT_ROOT_DIR, "simapro-biosphere.json")
-    simapro_categories_path = os.path.join(data_dir, "simapro_categories.csv")
-    references_path = os.path.join(data_dir, "references.csv")
+    simapro_biosphere_path = PROJECT_ROOT_DIR / "simapro-biosphere.json"
+    simapro_categories_path = data_dir / "simapro_categories.csv"
+    references_path = data_dir / "references.csv"
 
     simapro_export.export_db_to_simapro(
         db,

--- a/common/distances/transports.py
+++ b/common/distances/transports.py
@@ -5,7 +5,7 @@ from common.distances.CountryDistances import CountryDistances
 from common.export import load_json
 from config import PROJECT_ROOT_DIR, settings
 
-INPUT_DISTANCES = Path(PROJECT_ROOT_DIR) / "common/distances/distances_raw.json"
+INPUT_DISTANCES = PROJECT_ROOT_DIR / "common" / "distances" / "distances_raw.json"
 
 COUNTRIES_OFFICIAL = Path(settings.output_dir) / "countries.json"
 OUTPUT = Path(settings.output_dir) / "transports.json"

--- a/common/export.py
+++ b/common/export.py
@@ -1,7 +1,6 @@
 import json
 import math
 import os
-from os.path import dirname
 
 import matplotlib.pyplot
 import numpy
@@ -9,7 +8,7 @@ from frozendict import deepfreeze
 from rich.console import Console
 from rich.table import Table
 
-from config import settings
+from config import PROJECT_ROOT_DIR, settings
 from ecobalyse_data.logging import logger
 
 from . import (
@@ -19,9 +18,7 @@ from . import (
     remove_detailed_impacts,
 )
 
-PROJECT_ROOT_DIR = dirname(dirname(__file__))
-
-with open(os.path.join(PROJECT_ROOT_DIR, settings.impacts_file)) as f:
+with open(PROJECT_ROOT_DIR / settings.impacts_file) as f:
     IMPACTS_JSON = deepfreeze(json.load(f))
 
 

--- a/config.py
+++ b/config.py
@@ -1,15 +1,16 @@
 import logging
 import os
-from os.path import abspath, dirname, join
+from pathlib import Path
 
 from dynaconf import Dynaconf, Validator
 from platformdirs import user_cache_path
 
-PROJECT_ROOT_DIR = dirname(abspath(__file__))
+PROJECT_ROOT_DIR = Path.resolve(Path(__file__).parent)
+TESTS_FIXTURE_DIR = PROJECT_ROOT_DIR / "tests" / "fixtures"
 IS_CI = os.environ.get("CI") == "true"
 
 settings = Dynaconf(
-    root_path=PROJECT_ROOT_DIR,  # defining root_path
+    root_path=PROJECT_ROOT_DIR,
     envvar_prefix="EB",
     settings_files=["settings.toml"],
     environments=True,
@@ -50,9 +51,3 @@ settings = Dynaconf(
 
 
 ecosystemic_services_list = ["hedges", "plotSize", "cropDiversity"]
-
-
-def get_absolute_path(
-    relative_path, base_path=settings.get("base_path", PROJECT_ROOT_DIR)
-):
-    return join(base_path, relative_path)

--- a/settings.toml
+++ b/settings.toml
@@ -73,7 +73,6 @@ DIRNAME = "veli"
 [testing]
 ENV_NAME = "testing" # Do not override this value, it's used by the unit tests
 
-BASE_PATH = "tests/fixtures"
 LOCAL_EXPORT = false
 PLOT_EXPORT = false
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ import os
 #
 os.environ["FORCE_ENV_FOR_DYNACONF"] = "testing"
 
-from os.path import dirname
 
 import bw2data
 import orjson
@@ -24,19 +23,16 @@ from bw2data import config as bwconfig
 from bw2data import projects
 
 from common import brightway_patch as brightway_patch
-from config import settings
+from config import PROJECT_ROOT_DIR, TESTS_FIXTURE_DIR, settings
 from ecobalyse_data.tests import restore_archived_project
 
-PROJECT_ROOT_DIR = dirname(dirname(__file__))
+TESTS_SNAPSHOTS_DIR = PROJECT_ROOT_DIR / "tests" / "snapshots"
 
 
 @pytest.fixture
 def forwast(temp_bw_dir):
     restore_archived_project(
-        os.path.join(
-            PROJECT_ROOT_DIR,
-            "tests/fixtures/bw-project-forwast-with-patched-ef31.tar.gz",
-        )
+        TESTS_FIXTURE_DIR / "bw-project-forwast-with-patched-ef31.tar.gz"
     )
 
     bw2data.projects.set_current(settings.bw.project)
@@ -59,52 +55,38 @@ def temp_bw_dir(tmp_path):
 
 @pytest.fixture
 def forwast_json_icv():
-    with open(os.path.join(PROJECT_ROOT_DIR, "tests/fixtures/forwast.json"), "rb") as f:
+    with open(TESTS_FIXTURE_DIR / "forwast.json", "rb") as f:
         return orjson.loads(f.read())
 
 
 @pytest.fixture
 def processes_impacts_json():
-    with open(
-        os.path.join(PROJECT_ROOT_DIR, "tests/snapshots/processes_impacts.json"),
-        "rb",
-    ) as f:
+    with open(TESTS_SNAPSHOTS_DIR / "processes_impacts.json", "rb") as f:
         return orjson.loads(f.read())
 
 
 @pytest.fixture
 def ingredients_food_json():
-    with open(
-        os.path.join(PROJECT_ROOT_DIR, "tests/snapshots/food/ingredients.json"),
-        "rb",
-    ) as f:
+    with open(TESTS_SNAPSHOTS_DIR / "food" / "ingredients.json", "rb") as f:
         return orjson.loads(f.read())
 
 
 @pytest.fixture
 def materials_textile_json():
-    with open(
-        os.path.join(PROJECT_ROOT_DIR, "tests/snapshots/textile/materials.json"),
-        "rb",
-    ) as f:
+    with open(TESTS_SNAPSHOTS_DIR / "textile" / "materials.json", "rb") as f:
         return orjson.loads(f.read())
 
 
 @pytest.fixture
 def processes_impacts_full_json():
-    with open(
-        os.path.join(PROJECT_ROOT_DIR, "tests/snapshots/processes_impacts_full.json"),
-        "rb",
-    ) as f:
+    with open(TESTS_SNAPSHOTS_DIR / "processes_impacts_full.json", "rb") as f:
         return orjson.loads(f.read())
 
 
 @pytest.fixture
 def processes_generic_impacts_json():
     with open(
-        os.path.join(
-            PROJECT_ROOT_DIR, "tests/snapshots/processes_generic_impacts.json"
-        ),
+        TESTS_SNAPSHOTS_DIR / "processes_generic_impacts.json",
         "rb",
     ) as f:
         return orjson.loads(f.read())
@@ -112,13 +94,13 @@ def processes_generic_impacts_json():
 
 @pytest.fixture
 def ecs_factors_csv_file():
-    return os.path.join(PROJECT_ROOT_DIR, "tests/fixtures/food/ecosystemic_factors.csv")
+    return TESTS_FIXTURE_DIR / "food" / "ecosystemic_factors.csv"
 
 
 @pytest.fixture
 def ecs_factors_json():
     with open(
-        os.path.join(PROJECT_ROOT_DIR, "tests/snapshots/food/ecs_factors.json"),
+        TESTS_SNAPSHOTS_DIR / "food" / "ecs_factors.json",
         "rb",
     ) as f:
         return orjson.loads(f.read())

--- a/tests/test_ecosystemic_services.py
+++ b/tests/test_ecosystemic_services.py
@@ -1,10 +1,7 @@
 import json
-from os.path import dirname, join
 
-from config import settings
+from config import PROJECT_ROOT_DIR, settings
 from ecobalyse_data.export import food
-
-PROJECT_ROOT_DIR = dirname(dirname(__file__))
 
 
 def test_load_ecs_dic(ecs_factors_csv_file, ecs_factors_json):
@@ -17,7 +14,7 @@ def test_load_ecs_dic(ecs_factors_csv_file, ecs_factors_json):
 
 def test_feed_permanent_pasture():
     """Known grazing live animal has permanent pasture in its feed"""
-    feed_file_path = join(PROJECT_ROOT_DIR, "food", "ecosystemic_services", "feed.json")
+    feed_file_path = PROJECT_ROOT_DIR / "food" / "ecosystemic_services" / "feed.json"
 
     with open(feed_file_path) as f:
         content = json.load(f)
@@ -34,11 +31,11 @@ def test_feed_permanent_pasture():
 
 def test_animal_to_meat_keys_in_feed():
     """Every live animal in animal_to_meat.json must exist in feed.json"""
-    es_dir = join(PROJECT_ROOT_DIR, "food", "ecosystemic_services")
+    es_dir = PROJECT_ROOT_DIR / "food" / "ecosystemic_services"
 
-    with open(join(es_dir, "feed.json")) as f:
+    with open(es_dir / "feed.json") as f:
         feed = json.load(f)
-    with open(join(es_dir, "animal_to_meat.json")) as f:
+    with open(es_dir / "animal_to_meat.json") as f:
         animal_to_meat = json.load(f)
 
     for animal_alias in animal_to_meat:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,10 +1,8 @@
-import os
-
 import orjson
 
 from bin import export
 from common.export import export_json
-from config import settings
+from config import TESTS_FIXTURE_DIR, settings
 from create_activities import create_activities
 
 
@@ -12,12 +10,20 @@ def test_export_processes(forwast, tmp_path, processes_impacts_json):
     settings.set("OUTPUT_DIR", str(tmp_path))
     create_activities("tests/activities_to_create.json")
 
-    export.processes(scopes=None, simapro=False, plot=False, verbose=False, cpu_count=1)
+    export.processes(
+        scopes=None,
+        simapro=False,
+        plot=False,
+        verbose=False,
+        cpu_count=1,
+        root_dir=TESTS_FIXTURE_DIR,
+    )
 
-    with open(os.path.join(tmp_path, "processes_impacts.json"), "rb") as f:
+    with open(tmp_path / "processes_impacts.json", "rb") as f:
         json_data = orjson.loads(f.read())
         export_json(
-            json_data, os.path.join(settings.BASE_PATH, "processes_impacts_output.json")
+            json_data,
+            TESTS_FIXTURE_DIR / "processes_impacts_output.json",
         )
         assert json_data == processes_impacts_json
 
@@ -25,12 +31,15 @@ def test_export_processes(forwast, tmp_path, processes_impacts_json):
 def test_export_ingredients(forwast, tmp_path, ingredients_food_json):
     settings.set("OUTPUT_DIR", str(tmp_path))
 
-    output_path = os.path.join(tmp_path, "food")
-    os.makedirs(output_path)
+    output_path = tmp_path / "food"
+    output_path.mkdir()
 
-    export.metadata(scopes=[export.MetadataScope.food])
+    export.metadata(
+        scopes=[export.MetadataScope.food],
+        root_dir=TESTS_FIXTURE_DIR,
+    )
 
-    with open(os.path.join(output_path, "ingredients.json"), "rb") as f:
+    with open(output_path / "ingredients.json", "rb") as f:
         json_data = orjson.loads(f.read())
         assert json_data == ingredients_food_json
 
@@ -38,12 +47,15 @@ def test_export_ingredients(forwast, tmp_path, ingredients_food_json):
 def test_export_materials(forwast, tmp_path, materials_textile_json):
     settings.set("OUTPUT_DIR", str(tmp_path))
 
-    output_path = os.path.join(tmp_path, "textile")
-    os.makedirs(output_path)
+    output_path = tmp_path / "textile"
+    output_path.mkdir()
 
-    export.metadata(scopes=[export.MetadataScope.textile])
+    export.metadata(
+        scopes=[export.MetadataScope.textile],
+        root_dir=TESTS_FIXTURE_DIR,
+    )
 
-    with open(os.path.join(output_path, "materials.json"), "rb") as f:
+    with open(output_path / "materials.json", "rb") as f:
         json_data = orjson.loads(f.read())
         assert json_data == materials_textile_json
 
@@ -54,22 +66,22 @@ def test_export_processes_generic(
     settings.set("OUTPUT_DIR", str(tmp_path))
 
     # Write the full (unfiltered) processes data that the generic export reads
-    export_json(
-        processes_impacts_full_json,
-        os.path.join(tmp_path, "processes_impacts_full.json"),
-    )
+    export_json(processes_impacts_full_json, tmp_path / "processes_impacts_full.json")
     # Also write the regular file (needed for the path resolution)
     export_json(
         processes_impacts_full_json,
-        os.path.join(tmp_path, settings.processes_impacts_file),
+        tmp_path / settings.processes_impacts_file,
     )
 
-    export.metadata(scopes=[export.MetadataScope.object])
+    export.metadata(
+        scopes=[export.MetadataScope.object],
+        root_dir=TESTS_FIXTURE_DIR,
+    )
 
-    with open(os.path.join(tmp_path, "processes_generic_impacts.json"), "rb") as f:
+    with open(tmp_path / "processes_generic_impacts.json", "rb") as f:
         json_data = orjson.loads(f.read())
         export_json(
             json_data,
-            os.path.join(settings.BASE_PATH, "processes_generic_impacts_output.json"),
+            TESTS_FIXTURE_DIR / "processes_generic_impacts_output.json",
         )
         assert json_data == processes_generic_impacts_json

--- a/tests/test_process_relationships.py
+++ b/tests/test_process_relationships.py
@@ -1,41 +1,5 @@
-import os
-
-from rich.console import Console
-from rich.table import Table
-
 from common.export import load_json
-
-
-def log_duplicate_processes(process_id_counts, process_id_items, processes, item_type):
-    """Create a rich table to display duplicate process usage"""
-    if not any(count > 1 for count in process_id_counts.values()):
-        return
-
-    table = Table(
-        title=f"[yellow]⚠️  Duplicate Process Usage in {item_type}s.json[/yellow]",
-        show_header=True,
-        header_style="bold magenta",
-    )
-    table.add_column("ProcessId", style="cyan")
-    table.add_column("Process Name", style="green")
-    table.add_column("Count", justify="right", style="red")
-    table.add_column("Used By", style="blue")
-
-    for process_id, count in sorted(
-        process_id_counts.items(), key=lambda x: x[1], reverse=True
-    ):
-        if count > 1:
-            item_names = process_id_items[process_id]
-            table.add_row(
-                process_id,
-                processes[process_id].get("name", "Unknown"),
-                str(count),
-                "\n".join(item_names),
-            )
-
-    console = Console()
-    console.print(table)
-    console.print()
+from config import PROJECT_ROOT_DIR
 
 
 def check_process_relationships(items, processes, item_type):
@@ -59,40 +23,22 @@ def check_process_relationships(items, processes, item_type):
                 f"Process ID {process_id} from {item_type} {item.get('name', 'unknown')} not found in processes.json"
             )
 
-    # Check that each processId is used only once
-    process_id_counts = {}
-    process_id_items = {}
-
-    for item in items:
-        process_id = item.get("processId")
-        if process_id is None:
-            continue
-        process_id_counts[process_id] = process_id_counts.get(process_id, 0) + 1
-        if process_id not in process_id_items:
-            process_id_items[process_id] = []
-        process_id_items[process_id].append(item.get("name", "unknown"))
-
-    # Log duplicate process usage in a pretty table
-    log_duplicate_processes(process_id_counts, process_id_items, processes, item_type)
-
 
 def test_process_relationships():
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-    processes_path = os.path.join(base_dir, "public", "data", "processes.json")
+    processes_path = PROJECT_ROOT_DIR / "public" / "data" / "processes.json"
     processes_data = load_json(processes_path)
     processes = {p["id"]: p for p in processes_data}
 
     # Check ingredients against food processes
-    ingredients_path = os.path.join(
-        base_dir, "public", "data", "food", "ingredients.json"
+    ingredients_path = (
+        PROJECT_ROOT_DIR / "public" / "data" / "food" / "ingredients.json"
     )
+
     ingredients = load_json(ingredients_path)
     check_process_relationships(ingredients, processes, "ingredient")
 
     # Check materials against textile processes
-    materials_path = os.path.join(
-        base_dir, "public", "data", "textile", "materials.json"
-    )
+    materials_path = PROJECT_ROOT_DIR / "public" / "data" / "textile" / "materials.json"
+
     materials = load_json(materials_path)
     check_process_relationships(materials, processes, "material")


### PR DESCRIPTION
## :wrench: Problem

It was not really clear which files were used in the tests : the ones at the project root (ex: /activities.json) or the ones in the tests/fixtures folder

## :cake: Solution

Get rid of the opaque "get_absolute_path" and settings.BASE_DIR, ensure that we are using a unique PROJECT_ROOT_DIR variable, and manually pass the fixture folders path when needed.

Unrelated: also started replacing os.path by Pathlib.


