### PR TITLE
chore: add gaz to cooking

### DIFF
--- a/lci_catalog/custom/pan-cooking.json
+++ b/lci_catalog/custom/pan-cooking.json
@@ -5,7 +5,7 @@
   "comment": "Consommation d’électricité telle que définie par la méthode Agribalyse 3.0 dans les tableaux 41, 42, 43 sur les techniques de préparation.",
   "displayName": "Cuisson à la poêle",
   "elecMJ": 1.584,
-  "heatMJ": 0,
+  "heatMJ": 1.584,
   "id": "23f64752-4337-4ab2-bf11-7fe4a2f51b95",
   "impacts": {
     "acd": 0,

--- a/lci_catalog/custom/pan-reheating.json
+++ b/lci_catalog/custom/pan-reheating.json
@@ -5,7 +5,7 @@
   "comment": "Consommation d’électricité telle que définie par la méthode Agribalyse 3.0 dans les tableaux 41, 42, 43 sur les techniques de préparation.",
   "displayName": "Réchauffage à la poêle",
   "elecMJ": 0.288,
-  "heatMJ": 0,
+  "heatMJ": 0.288,
   "id": "2e834afa-ddb4-4c6c-9af6-88dd01c376b5",
   "impacts": {
     "acd": 0,


### PR DESCRIPTION
## :wrench: Problem

Fix https://github.com/MTES-MCT/ecobalyse/issues/1910

Also see https://github.com/MTES-MCT/ecobalyse/pull/2211


Les procédés d'utilisation cuisson et réchauffage poêle ont besoin de valeur dans heat pour mobiliser du gaz de ville.

## :cake: Solution

Ajouter des valeurs dans heat mobilisable par le procédé gaz de ville selon la documentation Agribalyse : https://fabrique-numerique.gitbook.io/ecobalyse/alimentaire/impacts-consideres/etape-5-consommation

