### PR TITLE
perf: multilca to compute land occupation

### DIFF
--- a/ecobalyse_data/computation.py
+++ b/ecobalyse_data/computation.py
@@ -177,9 +177,14 @@ def compute_brightway_impacts_batch(
     method_to_key = {tuple(m): k for k, m in impacts_py.items()}
 
     out = {}
+    total = len(bw_activities)
     for i in range(0, len(bw_activities), chunk_size):
         chunk_acts = bw_activities[i : i + chunk_size]
         chunk_amts = demand_amounts[i : i + chunk_size]
+        logger.info(
+            f"-> compute brightway impacts: chunk {i // chunk_size + 1}/"
+            f"{(total + chunk_size - 1) // chunk_size} ({len(chunk_acts)} activities)"
+        )
         # Use the bw_activity id as the demand key (string).
         demands = {str(a.id): {a.id: amt} for a, amt in zip(chunk_acts, chunk_amts)}
         data_objs = get_multilca_data_objs(

--- a/ecobalyse_data/export/export_generic.py
+++ b/ecobalyse_data/export/export_generic.py
@@ -119,7 +119,7 @@ def compute_processes_generic(
             load_ecosystemic_dic,
         )
 
-        food_activities = add_food_land_occupations(food_activities, cpu_count)
+        food_activities = add_food_land_occupations(food_activities)
         food_by_id = {a["id"]: a for a in food_activities}
         activities = [food_by_id.get(a["id"], a) for a in activities]
 
@@ -144,9 +144,7 @@ def compute_processes_generic(
                 break
 
     if activities_needing_land:
-        activities_needing_land = add_land_occupations(
-            activities_needing_land, cpu_count
-        )
+        activities_needing_land = add_land_occupations(activities_needing_land)
         land_by_id = {a["id"]: a for a in activities_needing_land}
         activities = [land_by_id.get(a["id"], a) for a in activities]
 
@@ -247,7 +245,7 @@ def activities_to_processes_generic_json(
     return generic_dicts
 
 
-def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
+def add_land_occupations(activities: List[dict]) -> List[dict]:
     todo = [a for a in activities if "landOccupation" not in a]
     bw_by_eco_id = {
         a["id"]: cached_search_one(

--- a/ecobalyse_data/export/export_generic.py
+++ b/ecobalyse_data/export/export_generic.py
@@ -248,37 +248,16 @@ def activities_to_processes_generic_json(
 
 
 def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
-    """Populate `landOccupation` on each activity that doesn't already have it,
-    batched through MultiLCA. `cpu_count` is unused (kept for signature
-    compatibility with the previous Pool-based path)."""
     todo = [a for a in activities if "landOccupation" not in a]
-
-    bw_by_eco_id: dict = {}
-    missing: List[str] = []
-    for activity in todo:
-        try:
-            bw_by_eco_id[activity["id"]] = cached_search_one(
-                activity.get("source"),
-                activity.get("activityName"),
-                location=activity.get("location"),
-            )
-        except Exception as e:
-            missing.append(
-                f"{activity.get('displayName') or activity.get('activityName')} "
-                f"(source={activity.get('source')}, location={activity.get('location')}): {e}"
-            )
-    if missing:
-        raise ValueError(
-            "Could not resolve bw_activity for land-occupation batch:\n  - "
-            + "\n  - ".join(missing)
+    bw_by_eco_id = {
+        a["id"]: cached_search_one(
+            a.get("source"), a.get("activityName"), location=a.get("location")
         )
-
+        for a in todo
+    }
     scores = compute_land_occupation_batch(list(bw_by_eco_id.values()))
-
     for activity in todo:
-        bw = bw_by_eco_id[activity["id"]]
-        activity["landOccupation"] = scores[bw.id]
-
+        activity["landOccupation"] = scores[bw_by_eco_id[activity["id"]].id]
     return activities
 
 

--- a/ecobalyse_data/export/export_generic.py
+++ b/ecobalyse_data/export/export_generic.py
@@ -1,15 +1,13 @@
 import json
 import os
-from multiprocessing import Pool
 from typing import List, Optional
 
-import bw2data
 import orjson
 
 from common import activities_processes_sort_key, remove_detailed_impacts
 from common.export import export_json
 from ecobalyse_data.bw.search import cached_search_one
-from ecobalyse_data.export.land_occupation import compute_land_occupation
+from ecobalyse_data.export.land_occupation import compute_land_occupation_batch
 from ecobalyse_data.export.utils import get_metadata_for_scope
 from ecobalyse_data.logging import logger
 from models.process import (
@@ -18,12 +16,6 @@ from models.process import (
     ProcessGeneric,
     Scope,
 )
-
-
-def _init_worker(project_name: str, base_dir: str):
-    """Initialize Brightway project in worker process."""
-    os.environ["BRIGHTWAY2_DIR"] = base_dir
-    bw2data.projects.set_current(project_name)
 
 
 def _build_variant_metadata(
@@ -255,44 +247,39 @@ def activities_to_processes_generic_json(
     return generic_dicts
 
 
-def add_land_occupation(activity: dict) -> dict:
-    """Add land occupation data to an object activity.
+def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
+    """Populate `landOccupation` on each activity that doesn't already have it,
+    batched through MultiLCA. `cpu_count` is unused (kept for signature
+    compatibility with the previous Pool-based path)."""
+    todo = [a for a in activities if "landOccupation" not in a]
 
-    Computes land occupation using Brightway data and stores it on the activity.
-
-    Args:
-        activity: A dictionary representing an object activity
-
-    Returns:
-        The activity dictionary with landOccupation added
-    """
-    if "landOccupation" in activity:
-        return activity
-
-    try:
-        bw_activity = cached_search_one(
-            activity.get("source"),
-            activity.get("activityName"),
-            location=activity.get("location"),
-        )
-        activity["landOccupation"] = compute_land_occupation(bw_activity)
-    except ValueError as e:
+    bw_by_eco_id: dict = {}
+    missing: List[str] = []
+    for activity in todo:
+        try:
+            bw_by_eco_id[activity["id"]] = cached_search_one(
+                activity.get("source"),
+                activity.get("activityName"),
+                location=activity.get("location"),
+            )
+        except Exception as e:
+            missing.append(
+                f"{activity.get('displayName') or activity.get('activityName')} "
+                f"(source={activity.get('source')}, location={activity.get('location')}): {e}"
+            )
+    if missing:
         raise ValueError(
-            f"Could not compute land occupation for {activity.get('displayName')}: {e}"
+            "Could not resolve bw_activity for land-occupation batch:\n  - "
+            + "\n  - ".join(missing)
         )
 
-    return activity
+    scores = compute_land_occupation_batch(list(bw_by_eco_id.values()))
 
+    for activity in todo:
+        bw = bw_by_eco_id[activity["id"]]
+        activity["landOccupation"] = scores[bw.id]
 
-def add_land_occupations(activities: List[dict], cpu_count: int) -> List[dict]:
-    """Add land occupation to all activities using multiprocessing."""
-    project_name = bw2data.projects.current
-    base_dir = str(bw2data.projects._base_data_dir)
-
-    with Pool(
-        cpu_count, initializer=_init_worker, initargs=(project_name, base_dir)
-    ) as pool:
-        return pool.map(add_land_occupation, activities)
+    return activities
 
 
 # Forest Management Coefficients

--- a/ecobalyse_data/export/food.py
+++ b/ecobalyse_data/export/food.py
@@ -1,7 +1,6 @@
 import csv
 import json
 from enum import StrEnum
-from multiprocessing import Pool
 from typing import List, Optional
 
 import matplotlib.pyplot as plt
@@ -12,7 +11,7 @@ from common.export import (
 )
 from config import settings
 from ecobalyse_data.bw.search import cached_search_one
-from ecobalyse_data.export.land_occupation import compute_land_occupation
+from ecobalyse_data.export.land_occupation import compute_land_occupation_batch
 from ecobalyse_data.export.utils import get_metadata_for_scope
 from ecobalyse_data.logging import logger
 from models.process import EcosystemicServices, Ingredient
@@ -281,52 +280,59 @@ def activities_to_ingredients_json(
     return ingredients_dicts
 
 
-def add_land_occupation(activity: dict) -> dict:
-    """Add land occupation data to a food activity.
+def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
+    """Populate `landOccupation` on every food metadata block that doesn't
+    already have a hardcoded value, batched through MultiLCA.
 
-    If the activity already has hardcoded land occupation values in its metadata,
-    those values are preserved. Otherwise, the land occupation is computed using
-    Brightway data.
+    `cpu_count` is accepted for signature compatibility with the previous
+    Pool-based path; it's unused (MultiLCA is single-threaded but solves a
+    chunk in one call).
 
-    Note: Hardcoded values are used when Brightway results differ significantly
-    from SimaPro calculations.
-
-    Land occupation is supposed to be specific to the source
-    and activityName, so the same value should applies to all metadata entries for an activity.
-
-    But in some cases we want to impose different values to differentiate ingredients, example : walnut-inshell-fr
-
-    Args:
-        activity: A dictionary representing a food activity with metadata
-
-    Returns:
-        The activity dictionary with land occupation data added to food metadata
+    Land occupation is per (source, activityName) — multiple metadata
+    entries on the same activity share the same computed value, but
+    `walnut-inshell-fr`-style metadata that explicitly hardcodes
+    `landOccupation` overrides per-entry.
     """
-    land_occupation = None
-
-    for food_metadata in get_metadata_for_scope(activity, "food"):
-        hardcoded = food_metadata.get("landOccupation")
-        if hardcoded:
-            logger.debug(
-                f"-> Not computing land occupation for {food_metadata['alias']}, value is already hardcoded"
-            )
-        else:
-            if not land_occupation:
-                land_occupation = compute_land_occupation(
-                    cached_search_one(
-                        activity.get("source"),
-                        activity.get("activityName"),
-                        location=activity.get("location"),
-                    )
+    needs_compute: List = []  # list[tuple[activity, food_metadata]]
+    for activity in activities:
+        for food_metadata in get_metadata_for_scope(activity, "food"):
+            if food_metadata.get("landOccupation"):
+                logger.debug(
+                    f"-> Not computing land occupation for {food_metadata['alias']}, value is already hardcoded"
                 )
-            food_metadata["landOccupation"] = land_occupation
+                continue
+            needs_compute.append((activity, food_metadata))
 
-    return activity
+    bw_by_eco_id: dict = {}
+    missing: List[str] = []
+    for activity, _ in needs_compute:
+        eco_id = activity["id"]
+        if eco_id in bw_by_eco_id:
+            continue
+        try:
+            bw_by_eco_id[eco_id] = cached_search_one(
+                activity.get("source"),
+                activity.get("activityName"),
+                location=activity.get("location"),
+            )
+        except Exception as e:
+            missing.append(
+                f"{activity.get('displayName') or activity.get('activityName')} "
+                f"(source={activity.get('source')}, location={activity.get('location')}): {e}"
+            )
+    if missing:
+        raise ValueError(
+            "Could not resolve bw_activity for land-occupation batch:\n  - "
+            + "\n  - ".join(missing)
+        )
 
+    scores = compute_land_occupation_batch(list(bw_by_eco_id.values()))
 
-def add_land_occupations(activities: List[dict], cpu_count) -> List[dict]:
-    with Pool(cpu_count) as pool:
-        return pool.map(add_land_occupation, activities)
+    for activity, food_metadata in needs_compute:
+        bw = bw_by_eco_id[activity["id"]]
+        food_metadata["landOccupation"] = scores[bw.id]
+
+    return activities
 
 
 def activities_to_ingredients(

--- a/ecobalyse_data/export/food.py
+++ b/ecobalyse_data/export/food.py
@@ -281,57 +281,25 @@ def activities_to_ingredients_json(
 
 
 def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
-    """Populate `landOccupation` on every food metadata block that doesn't
-    already have a hardcoded value, batched through MultiLCA.
-
-    `cpu_count` is accepted for signature compatibility with the previous
-    Pool-based path; it's unused (MultiLCA is single-threaded but solves a
-    chunk in one call).
-
-    Land occupation is per (source, activityName) — multiple metadata
-    entries on the same activity share the same computed value, but
-    `walnut-inshell-fr`-style metadata that explicitly hardcodes
-    `landOccupation` overrides per-entry.
-    """
-    needs_compute: List = []  # list[tuple[activity, food_metadata]]
+    needs_compute = []
     for activity in activities:
         for food_metadata in get_metadata_for_scope(activity, "food"):
-            if food_metadata.get("landOccupation"):
-                logger.debug(
-                    f"-> Not computing land occupation for {food_metadata['alias']}, value is already hardcoded"
-                )
-                continue
-            needs_compute.append((activity, food_metadata))
+            if not food_metadata.get("landOccupation"):
+                needs_compute.append((activity, food_metadata))
 
-    bw_by_eco_id: dict = {}
-    missing: List[str] = []
+    bw_by_eco_id = {}
     for activity, _ in needs_compute:
         eco_id = activity["id"]
-        if eco_id in bw_by_eco_id:
-            continue
-        try:
+        if eco_id not in bw_by_eco_id:
             bw_by_eco_id[eco_id] = cached_search_one(
                 activity.get("source"),
                 activity.get("activityName"),
                 location=activity.get("location"),
             )
-        except Exception as e:
-            missing.append(
-                f"{activity.get('displayName') or activity.get('activityName')} "
-                f"(source={activity.get('source')}, location={activity.get('location')}): {e}"
-            )
-    if missing:
-        raise ValueError(
-            "Could not resolve bw_activity for land-occupation batch:\n  - "
-            + "\n  - ".join(missing)
-        )
 
     scores = compute_land_occupation_batch(list(bw_by_eco_id.values()))
-
     for activity, food_metadata in needs_compute:
-        bw = bw_by_eco_id[activity["id"]]
-        food_metadata["landOccupation"] = scores[bw.id]
-
+        food_metadata["landOccupation"] = scores[bw_by_eco_id[activity["id"]].id]
     return activities
 
 

--- a/ecobalyse_data/export/food.py
+++ b/ecobalyse_data/export/food.py
@@ -288,6 +288,26 @@ def activities_to_ingredients_json(
 
 
 def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
+    """Add land occupation data to a food activity.
+
+    If the activity already has hardcoded land occupation values in its metadata,
+    those values are preserved. Otherwise, the land occupation is computed using
+    Brightway data.
+
+    Note: Hardcoded values are used when Brightway results differ significantly
+    from SimaPro calculations.
+
+    Land occupation is supposed to be specific to the source
+    and activityName, so the same value should applies to all metadata entries for an activity.
+
+    But in some cases we want to impose different values to differentiate ingredients, example : walnut-inshell-fr
+
+    Args:
+        activities: A list of activities
+
+    Returns:
+        The activities list with land occupation data added to food metadata
+    """
     needs_compute = []
     for activity in activities:
         for food_metadata in get_metadata_for_scope(activity, "food"):

--- a/ecobalyse_data/export/food.py
+++ b/ecobalyse_data/export/food.py
@@ -258,7 +258,7 @@ def activities_to_ingredients_json(
     with open(raw_to_transformed_file_path, "r") as file:
         raw_to_transformed = json.load(file)
 
-    activities_with_land_occupation = add_land_occupations(activities, cpu_count)
+    activities_with_land_occupation = add_land_occupations(activities)
 
     ingredients = activities_to_ingredients(
         activities_with_land_occupation,
@@ -287,32 +287,21 @@ def activities_to_ingredients_json(
     return ingredients_dicts
 
 
-def add_land_occupations(activities: List[dict], cpu_count=None) -> List[dict]:
-    """Add land occupation data to a food activity.
+def add_land_occupations(activities: List[dict]) -> List[dict]:
+    """Populate `landOccupation` on every food metadata block via MultiLCA.
 
-    If the activity already has hardcoded land occupation values in its metadata,
-    those values are preserved. Otherwise, the land occupation is computed using
-    Brightway data.
-
-    Note: Hardcoded values are used when Brightway results differ significantly
-    from SimaPro calculations.
-
-    Land occupation is supposed to be specific to the source
-    and activityName, so the same value should applies to all metadata entries for an activity.
-
-    But in some cases we want to impose different values to differentiate ingredients, example : walnut-inshell-fr
-
-    Args:
-        activities: A list of activities
-
-    Returns:
-        The activities list with land occupation data added to food metadata
+    Hardcoded values (e.g. `walnut-inshell-fr`) are preserved. One score per
+    (source, activityName) is shared across all metadata entries of an activity.
     """
     needs_compute = []
     for activity in activities:
         for food_metadata in get_metadata_for_scope(activity, "food"):
-            if not food_metadata.get("landOccupation"):
-                needs_compute.append((activity, food_metadata))
+            if food_metadata.get("landOccupation"):
+                logger.debug(
+                    f"-> Not computing land occupation for {food_metadata['alias']}, value is already hardcoded"
+                )
+                continue
+            needs_compute.append((activity, food_metadata))
 
     bw_by_eco_id = {}
     for activity, _ in needs_compute:

--- a/ecobalyse_data/export/land_occupation.py
+++ b/ecobalyse_data/export/land_occupation.py
@@ -12,30 +12,23 @@ LAND_OCCUPATION_METHOD: Tuple[str, str, str] = (
 )
 
 
-def compute_land_occupation(
-    bw_activity,
-    land_occupation_method: Tuple[str, str, str] = LAND_OCCUPATION_METHOD,
-):
-    logger.debug(f"-> Computing land occupation for {bw_activity}")
-    lca = bw2calc.LCA({bw_activity: 1})
-    lca.lci()
-    lca.switch_method(land_occupation_method)
-    lca.lcia()
-    logger.debug(f"-> Finished computing land occupation for {bw_activity} {lca.score}")
-
-    return float(lca.score)
-
-
-def compute_land_occupation_batch(bw_activities, chunk_size: int = 50) -> dict:
-    """Batched equivalent of compute_land_occupation via MultiLCA."""
+def compute_land_occupation_batch(
+    bw_activities, chunk_size: int = 200
+) -> dict[int, float]:
+    """Return {bw_activity.id: land_occupation_score} via a chunked MultiLCA."""
     unique = list({a.id: a for a in bw_activities}.values())
     if not unique:
         return {}
 
     method_config = {"impact_categories": [LAND_OCCUPATION_METHOD]}
-    out = {}
-    for i in range(0, len(unique), chunk_size):
+    out: dict[int, float] = {}
+    total = len(unique)
+    for i in range(0, total, chunk_size):
         chunk = unique[i : i + chunk_size]
+        logger.info(
+            f"-> land occupation: chunk {i // chunk_size + 1}/"
+            f"{(total + chunk_size - 1) // chunk_size} ({len(chunk)} activities)"
+        )
         demands = {str(a.id): {a.id: 1} for a in chunk}
         data_objs = get_multilca_data_objs(
             functional_units=demands, method_config=method_config

--- a/ecobalyse_data/export/land_occupation.py
+++ b/ecobalyse_data/export/land_occupation.py
@@ -13,7 +13,7 @@ LAND_OCCUPATION_METHOD: Tuple[str, str, str] = (
 
 
 def compute_land_occupation_batch(
-    bw_activities, chunk_size: int = 200
+    bw_activities, chunk_size: int = 1000
 ) -> dict[int, float]:
     """Return {bw_activity.id: land_occupation_score} via a chunked MultiLCA."""
     unique = list({a.id: a for a in bw_activities}.values())

--- a/ecobalyse_data/export/land_occupation.py
+++ b/ecobalyse_data/export/land_occupation.py
@@ -1,17 +1,20 @@
 from typing import Tuple
 
 import bw2calc
+from bw2data import get_multilca_data_objs
 
 from ecobalyse_data.logging import logger
+
+LAND_OCCUPATION_METHOD: Tuple[str, str, str] = (
+    "selected LCI results",
+    "resource",
+    "land occupation",
+)
 
 
 def compute_land_occupation(
     bw_activity,
-    land_occupation_method: Tuple[str, str, str] = (
-        "selected LCI results",
-        "resource",
-        "land occupation",
-    ),
+    land_occupation_method: Tuple[str, str, str] = LAND_OCCUPATION_METHOD,
 ):
     logger.debug(f"-> Computing land occupation for {bw_activity}")
     lca = bw2calc.LCA({bw_activity: 1})
@@ -21,3 +24,36 @@ def compute_land_occupation(
     logger.debug(f"-> Finished computing land occupation for {bw_activity} {lca.score}")
 
     return float(lca.score)
+
+
+def compute_land_occupation_batch(
+    bw_activities,
+    chunk_size: int = 50,
+) -> dict:
+    """Return {bw_activity.id: land_occupation_score} for all inputs.
+
+    Numerically equivalent to per-activity compute_land_occupation, but
+    builds the technosphere matrix once per chunk and solves the linear
+    system for many demands at once via MultiLCA. Drop-in replacement
+    for the per-activity Pool path."""
+    by_id = {a.id: a for a in bw_activities}
+    unique = list(by_id.values())
+    if not unique:
+        return {}
+
+    method_config = {"impact_categories": [LAND_OCCUPATION_METHOD]}
+    out: dict = {}
+    for i in range(0, len(unique), chunk_size):
+        chunk = unique[i : i + chunk_size]
+        demands = {str(a.id): {a.id: 1} for a in chunk}
+        data_objs = get_multilca_data_objs(
+            functional_units=demands, method_config=method_config
+        )
+        mlca = bw2calc.MultiLCA(
+            demands=demands, method_config=method_config, data_objs=data_objs
+        )
+        mlca.lci()
+        mlca.lcia()
+        for (_method_t, fu_name), ci in mlca.characterized_inventories.items():
+            out[int(fu_name)] = float(ci.sum())
+    return out

--- a/ecobalyse_data/export/land_occupation.py
+++ b/ecobalyse_data/export/land_occupation.py
@@ -26,23 +26,14 @@ def compute_land_occupation(
     return float(lca.score)
 
 
-def compute_land_occupation_batch(
-    bw_activities,
-    chunk_size: int = 50,
-) -> dict:
-    """Return {bw_activity.id: land_occupation_score} for all inputs.
-
-    Numerically equivalent to per-activity compute_land_occupation, but
-    builds the technosphere matrix once per chunk and solves the linear
-    system for many demands at once via MultiLCA. Drop-in replacement
-    for the per-activity Pool path."""
-    by_id = {a.id: a for a in bw_activities}
-    unique = list(by_id.values())
+def compute_land_occupation_batch(bw_activities, chunk_size: int = 50) -> dict:
+    """Batched equivalent of compute_land_occupation via MultiLCA."""
+    unique = list({a.id: a for a in bw_activities}.values())
     if not unique:
         return {}
 
     method_config = {"impact_categories": [LAND_OCCUPATION_METHOD]}
-    out: dict = {}
+    out = {}
     for i in range(0, len(unique), chunk_size):
         chunk = unique[i : i + chunk_size]
         demands = {str(a.id): {a.id: 1} for a in chunk}


### PR DESCRIPTION
## :wrench: Problem

Fix https://github.com/MTES-MCT/ecobalyse/issues/2202 

- remove cpu_count as multiprocessing doesn't improve perf

On my machine `uv run python ./bin/export.py metadata` goes from 20min to 50s 🎉🤯

## How to test

- just export-all should be faster and no diff