### PR TITLE
chore: resync ecobalyse-data and optimize chunk_size

### DIFF
--- a/ecobalyse_data/export/land_occupation.py
+++ b/ecobalyse_data/export/land_occupation.py
@@ -13,7 +13,7 @@ LAND_OCCUPATION_METHOD: Tuple[str, str, str] = (
 
 
 def compute_land_occupation_batch(
-    bw_activities, chunk_size: int = 1000
+    bw_activities, chunk_size: int = 200
 ) -> dict[int, float]:
     """Return {bw_activity.id: land_occupation_score} via a chunked MultiLCA."""
     unique = list({a.id: a for a in bw_activities}.values())

--- a/public/data/processes_generic.json
+++ b/public/data/processes_generic.json
@@ -60133,7 +60133,7 @@
     "displayName": "Cellule de batterie, LFP Solid State, CN",
     "elecMJ": 0,
     "heatMJ": 0,
-    "id": "fe88a1fe-95f7-4aa6-b1b4-278a4cdceb2d",
+    "id": "7fdb9ec7-b1bc-43b0-b7c1-6dcc3ec27812",
     "impacts": {
       "acd": 0,
       "cch": 0,


### PR DESCRIPTION
## :wrench: Problem

- Last [PR](https://github.com/MTES-MCT/ecobalyse-data/pull/298) was merged too fast and there is an desync
 
- for land_occupation compute, chunk_size = 200 is 10s (10%) faster on my machine that chunk_size = 1000
